### PR TITLE
ADX-281 Initialise the validation db tables before running tests.

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -180,7 +180,8 @@ def reset_test_db(args, extra):
                   f' ckan ckan-paster datastore set-permissions -c test-core.ini | docker exec -i db psql -U {PG_USER}'])
     call_command([f'docker exec -e CKAN_SQLALCHEMY_URL="{CKAN_TEST_SQLALCHEMY_URL}"'
                   f' ckan ckan-paster db init -c test-core.ini'])
-
+    call_command([f'docker exec -e CKAN_SQLALCHEMY_URL="{CKAN_TEST_SQLALCHEMY_URL}"'
+              f' ckan ckan-paster --plugin=ckanext-validation validation init-db -c test-core.ini'])
 
 def run_tests(args, extra):
     extension_name = "ckanext-" + args.extension


### PR DESCRIPTION
In order to run ckanext-unaids tests locally, errors were being thrown that Validation tables did not exist.  The validation plugin requires a db init step. I have added this db init step to the testsetup command here. 