### PR TITLE
ADX-407 Remove restricted presets file from config.

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -122,7 +122,6 @@ scheming.presets = ckanext.scheming:presets.json
                    ckanext.repeating:presets.json
                    ckanext.composite:presets.json
                    ckanext.unaids:presets.json
-                   ckanext.restricted:presets.json
                    ckanext.validation:presets.json
 
 # CMS Settings


### PR DESCRIPTION
Ckanext Restricted has been really bugging me for a while. This was set up very early in the project's lifestyle. I've spent a while de coupling it from scheming, cleaning up the UI and the configs.

I have also moved the creation of the restricted json string from a validator to the client side as it is a far cleaner way of working with and debugging the software. This also helps decouple the extension from the scheming extension and create behaviour more inline with restricted tests.

There are a number of related PRS.