### PR TITLE
ADX-409 Run ckanext-scheming tests locally with pytest.

### DIFF
--- a/adx
+++ b/adx
@@ -187,6 +187,8 @@ actions['test'] = subparsers.add_parser(
 actions['test'].set_defaults(func=util.run_tests)
 actions['test'].add_argument('extension', metavar='name', type=str,
                              help='The extension name e.g."validation", "ytp-request"')
+actions['test'].add_argument('-p', '--pytest',  action='store_true',
+                             help='Use pytest instead of nosetest')
 
 parser.add_argument(
     "-log",

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -45,6 +45,7 @@ RUN mkdir -p $CKAN_VENV $CKAN_CONFIG $CKAN_STORAGE_PATH && \
     ln -s $CKAN_VENV/bin/paster /usr/local/bin/ckan-paster &&\
     ln -s $CKAN_VENV/bin/python /usr/local/bin/ckan-python &&\
     ln -s $CKAN_VENV/bin/nosetests-2.7 /usr/local/bin/ckan-nosetests &&\
+	ln -s $CKAN_VENV/bin/pytest /usr/local/bin/ckan-pytest &&\
     echo "alias ckanext='cd /usr/lib/adx/'" >> $HOME/.bashrc &&\
     echo "alias ckan='cd /usr/lib/ckan/venv/src/ckan'" >> $HOME/.bashrc
 
@@ -78,7 +79,8 @@ RUN ckan-pip install -e "git+https://github.com/fjelltopp/ckanext-googleanalytic
 
 # Install requirements for extensions with a local source
 COPY ./ckanext-scheming/requirements.txt /usr/lib/ckan/scheming-requirements.txt
-RUN ckan-pip install -r /usr/lib/ckan/scheming-requirements.txt
+COPY ./ckanext-scheming/test-requirements.txt /usr/lib/ckan/test-scheming-requirements.txt
+RUN ckan-pip install -r /usr/lib/ckan/scheming-requirements.txt -r /usr/lib/ckan/test-scheming-requirements.txt
 
 COPY ./ckanext-geoview/pip-requirements.txt /usr/lib/ckan/geoview-requirements.txt
 RUN ckan-pip install -r /usr/lib/ckan/geoview-requirements.txt

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from multiprocessing.context import Process
-
+import logging
 import sys
 from . import repo
 from time import sleep
@@ -181,18 +181,31 @@ def reset_test_db(args, extra):
     call_command([f'docker exec -e CKAN_SQLALCHEMY_URL="{CKAN_TEST_SQLALCHEMY_URL}"'
                   f' ckan ckan-paster db init -c test-core.ini'])
     call_command([f'docker exec -e CKAN_SQLALCHEMY_URL="{CKAN_TEST_SQLALCHEMY_URL}"'
-              f' ckan ckan-paster --plugin=ckanext-validation validation init-db -c test-core.ini'])
+                  f' ckan ckan-paster --plugin=ckanext-validation validation init-db -c test-core.ini'])
     call_command([f'docker exec -e CKAN_SQLALCHEMY_URL="{CKAN_TEST_SQLALCHEMY_URL}"'
-              f' ckan ckan-paster --plugin=ckanext-ytp-request initdb -c test-core.ini'])
+                  f' ckan ckan-paster --plugin=ckanext-ytp-request initdb -c test-core.ini'])
+
 
 def run_tests(args, extra):
     extension_name = "ckanext-" + args.extension
     extension_path = "/usr/lib/adx/" + extension_name
     extension_sub_path = "/".join(extension_name.split("-"))
-    call_command([f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} ckan /usr/local/bin/ckan-nosetests --ckan'
-                  f' --with-pylons={extension_path}/test.ini'
-                  f' {extension_path}/{extension_sub_path}/tests --logging-level=WARNING']
-                 + extra)
+    if args.pytest:
+        call_command([
+            f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
+            f'ckan /usr/local/bin/ckan-pytest'
+            f' --ckan-ini={extension_path}/test.ini'
+            f' {extension_path}/{extension_sub_path}/tests '
+            f'--log-level=WARNING'
+        ] + extra)
+    else:
+        call_command([
+            f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
+            f'ckan /usr/local/bin/ckan-nosetests --ckan'
+            f' --with-pylons={extension_path}/test.ini'
+            f' {extension_path}/{extension_sub_path}/tests '
+            f'--logging-level=WARNING'
+        ] + extra)
 
 
 def deploy_master(args, extra):


### PR DESCRIPTION
We should be able to merge this straight away.  It does two things:

- Adds the ability to run `adx test` using pytest instead of nosetest.  This is done with the `-p` arg. 
- Installs the test requirements for scheming upon building the docker container. These test requirements for scheming exist in both the upadted ckanext-scheming and the original ckanext-scheming. 