### PR TITLE
Adx 407 Install jinja2 == 2.11

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -98,6 +98,9 @@ RUN ckan-pip install -r /usr/lib/ckan/dhis2-harvester-requriments.txt -r /usr/li
 COPY ./ckanext-file_uploader_ui/requirements.txt /usr/lib/ckan/file_uploader_ui-requirements.txt
 RUN ckan-pip install -r /usr/lib/ckan/file_uploader_ui-requirements.txt
 
+COPY ./ckanext-restricted/requirements.txt /usr/lib/ckan/restricted-requirements.txt
+RUN ckan-pip install -r /usr/lib/ckan/restricted-requirements.txt
+
 RUN rm /usr/lib/ckan/*-requirements.txt
 # Configs
 COPY ./adx_develop/ckan/ckan-entrypoint-adx.sh /ckan-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - CKAN_SOLR_URL=http://solr:8983/solr/ckan
       - CKAN_REDIS_URL=redis://redis:6379/1
       - CKAN_DATAPUSHER_URL=http://datapusher:8800/
+      - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ckan_storage:/var/lib/ckan
       - ../:/usr/lib/adx


### PR DESCRIPTION
I've also slipped in an env var that should stop writing all these pyc and pycache files to the host. 