### PR TITLE
ADX-463 Move back to syncronous validation.

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -119,8 +119,8 @@ ckanext.file_uploader_ui_path = resources/file_uploader_ui
 ckanext.file_uploader_ui_defaults = {"restricted_allowed_orgs": "unaids"}
 
 ckanext.validation.schema_directory = /usr/lib/adx/unaids_data_specifications/table_schemas
-ckanext.validation.run_on_create_async = True
-ckanext.validation.run_on_update_async = True
+ckanext.validation.run_on_create_sync = True
+ckanext.validation.run_on_update_sync = True
 ckanext.validation.allow_invalid_data = True
 ckanext.validation.default_validation_options = {"row_limit": 5000, "error_limit": 100, "skip_checks": ["extra-header"] }
 ckanext.validation.formats = csv xlsx xls shp geojson

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -113,7 +113,7 @@ ckan.redis.url = redis://redis:6379/1
 #		Add ``resource_proxy`` to enable resorce proxying and get around the
 #		same origin policy
 # Note: Plugins to the left take precendence over plugins to the right!!! Opposite to what you might expect.
-ckan.plugins = unaids emailasusername stats text_view image_view recline_view recline_graph_view recline_map_view recline_grid_view file_uploader_ui resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite validation scheming_datasets repeating restricted ytp_request pages harvest dhis2harvester_plugin dhis2_pivot_tables_harvester
+ckan.plugins = unaids emailasusername stats text_view image_view unaids_recline_view recline_graph_view recline_map_view recline_grid_view file_uploader_ui resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite validation scheming_datasets repeating restricted ytp_request pages harvest dhis2harvester_plugin dhis2_pivot_tables_harvester
 
 ckanext.file_uploader_ui_path = resources/file_uploader_ui
 ckanext.file_uploader_ui_defaults = {"restricted_allowed_orgs": "unaids"}
@@ -144,7 +144,7 @@ ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.type = redis
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
-ckan.views.default_views = pdf_view image_view text_view recline_view geojson_view
+ckan.views.default_views = pdf_view image_view text_view geojson_view unaids_recline_view 
 
 # Customize which text formats the text_view plugin will show
 ckan.preview.json_formats = json

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -194,7 +194,7 @@ def run_tests(args, extra):
     if args.pytest:
         call_command([
             f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
-            f'ckan /usr/local/bin/ckan-pytest'
+            f'ckan /usr/local/bin/ckan-pytest --disable-warnings'
             f' --ckan-ini={extension_path}/test.ini'
             f' {extension_path}/{extension_sub_path}/tests '
             f'--log-level=WARNING'

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -148,7 +148,7 @@ def init_ckan_db(args, extra):
     call_command(['docker exec -it ckan /usr/local/bin/ckan-paster --plugin=ckanext-validation validation init-db -c /etc/ckan/ckan.ini'])
 
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini datastore set-permissions | docker exec -i db psql -U ckan'])
-    call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini user add admin email=admin@localhost name=admin password=fjelltopp apikey=a4bf5640-e1b2-4141-8c22-f2b96b6df2c3'])
+    call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini user add admin email=admin@localhost name=admin fullname=Admin password=fjelltopp apikey=a4bf5640-e1b2-4141-8c22-f2b96b6df2c3'])
     call_command([f'docker exec db psql -U {PG_USER} -c "UPDATE public.user SET apikey = \'{ADMIN_APIKEY}\' WHERE name = \'admin\';"'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini sysadmin add admin'])
 


### PR DESCRIPTION
This pr puts us back to syncronous validation.  

I've confirmed that things work pretty smoothly both async and sync.  Using sync validation just provides much better UX in my opinion - you change the file, wait for the page to reload and your validation status is there waiting for you.    Creates a bit of a problem though for large survey/population datasets as the requests hangs for a long time - sometimes I fear longer than the current max request time.  Would appreciate discussing this with other folk. 

I wonder whether we could explore using a JS throbber to improve the experience.