### PR TITLE
Adx 284 auth

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -74,7 +74,7 @@ ckan.auth.roles_that_cascade_to_sub_groups = admin
 ckan.auth.public_user_details = false
 ckan.auth.public_activity_stream_detail = true
 ckan.auth.allow_dataset_collaborators = false
-ckan.auth.create_default_api_keys = false
+ckan.auth.create_default_api_keys = true
 
 ## API Token Settings
 api_token.nbytes = 60

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -73,7 +73,8 @@ ckan.auth.create_user_via_web = true
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 ckan.auth.public_user_details = false
 ckan.auth.public_activity_stream_detail = true
-ckan.auth.allow_dataset_collaborators = false
+ckan.auth.allow_dataset_collaborators = true
+ckan.auth.allow_admin_collaborators = true
 ckan.auth.create_default_api_keys = true
 
 ## API Token Settings


### PR DESCRIPTION
Changes three config settings for ckan 2.9:

- New users registered aren't given an api key by default.  This could cause some confusion re naomi integration.  I have set the config so that default api keys are assigned upon creating the user.
-  Enable collaborators feature - really nice feature.  See related pr: https://github.com/fjelltopp/ckanext-unaids/pull/81
- Allow admin collaborators - users from another org who can not only read and edit data but also edit collaborators on a data set.  The feature works well. 

Yes ideally this should have been pegged to a seperate jira issue, but it began as a small config change and grew to  small change+template override so we are where we are.  It's not worth spending the time needed to change it, given the issue is already wrapped up. 