### PR TITLE
SMTP config is handle by ENV in adx_deploy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Docker-compose
 9. CKAN should be available at http://localhost:5000
 
 
+## Using a fake SMTP server locally
+
+It might be useful to test features which requires sending e-mail. To do so you can setup a fake SMTP server locally:
+```
+python3 -m smtpd -n -c DebuggingServer localhost:25
+```
+Instead of `localhost` you might want to bind to an IP accessible both from your host and from ADR containers.
+
+In Ubunut you can use the IP of docker deamon, e.g. `172.17.0.1`.
+Update your `docker-compose.yml` accordingly.
 ## Running CKAN tests locally
 
 CKAN tests can be run in the development environment, but some setup is required.

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -228,17 +228,6 @@ ckan.activity_streams_email_notifications = true
 ckan.email_notifications_since = 2 days
 ckan.hide_activity_from_users = %(ckan.site_id)s
 
-## Email settings
-
-email_to = support@fjelltopp.org
-#error_email_from = ckan-errors@example.com
-smtp.server = email-smtp.eu-west-1.amazonaws.com:587
-smtp.starttls = True
-# smtp.user = username@example.com # SET USING ENV VAR
-# smtp.password = your_password # SET USING ENV VAR
-smtp.mail_from = support@fjelltopp.org
-
-
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext, ckanext_emailasusername, werkzeug

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -228,6 +228,9 @@ ckan.activity_streams_email_notifications = true
 ckan.email_notifications_since = 2 days
 ckan.hide_activity_from_users = %(ckan.site_id)s
 
+# Email Settings
+email_to = support@fjelltopp.org
+
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext, ckanext_emailasusername, werkzeug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,9 @@ services:
       - CKAN_SOLR_URL=http://solr:8983/solr/ckan
       - CKAN_REDIS_URL=redis://redis:6379/1
       - CKAN_DATAPUSHER_URL=http://datapusher:8800/
-      - CKAN_EMAIL_TO = support@fjelltopp_org
-      - CKAN_SMTP_SERVER = localhost:25
-      - CKAN_SMTP_STARTTLS = False
-      - CKAN_SMTP_MAIL_FROM = support@fjelltopp_org
+      - CKAN_SMTP_SERVER=localhost:25
+      - CKAN_SMTP_STARTTLS=False
+      - CKAN_SMTP_MAIL_FROM=support@fjelltopp_org
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ckan_storage:/var/lib/ckan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       - CKAN_SOLR_URL=http://solr:8983/solr/ckan
       - CKAN_REDIS_URL=redis://redis:6379/1
       - CKAN_DATAPUSHER_URL=http://datapusher:8800/
+      - CKAN_EMAIL_TO = support@fjelltopp_org
+      - CKAN_SMTP_SERVER = localhost:25
+      - CKAN_SMTP_STARTTLS = False
+      - CKAN_SMTP_MAIL_FROM = support@fjelltopp_org
       - PYTHONDONTWRITEBYTECODE=1
     volumes:
       - ckan_storage:/var/lib/ckan


### PR DESCRIPTION
Added README.md section on how to setup a fake SMTP for local dev.

Example usage of local fake SMTP server with ADR:
```
➜  adx sudo python3 -m smtpd -n -c DebuggingServer 172.17.0.1:25


---------- MESSAGE FOLLOWS ----------
b'Content-Type: text/plain; charset="utf-8"'
b'MIME-Version: 1.0'
b'Content-Transfer-Encoding: base64'
b'Subject: =?utf-8?q?New_Registration=3A_tomek2_=28tomek+2=40fjelltopp=2Eorg=29?='
b'From: The AIDS Data Repository <support@fjelltopp.org>'
b'To: CKAN System Administrator <support@fjelltopp.org>'
b'Date: Fri, 06 Nov 2020 12:36:38 -0000'
b'X-Mailer: CKAN 2.9.1'
b'X-Peer: 172.23.0.7'
b''
b'RGVhciBUaGUgQUlEUyBEYXRhIFJlcG9zaXRvcnkgYWRtaW5pc3RyYXRvciwKCkEgbmV3IHVzZXIg'
b'cmVnaXN0ZXJlZCwgcGxlYXNlIHJldmlldyB0aGUgaW5mb3JtYXRpb246CiogRU1BSUxfSEFTSDog'
b'YjEzY2NmMDZmZWU2ZDZhYTI1OTdmN2Q1YmRiNDcxMjMKKiBBQk9VVDogTm9uZQoqIEFQSUtFWTog'
b'MWUwYmRlZGUtODgwMS00OGYyLWFjMmUtYzBmN2M2NTY4NGQyCiogRElTUExBWV9OQU1FOiBUb21l'
b'awoqIE5BTUU6IHRvbWVrMgoqIENSRUFURUQ6IDIwMjAtMTEtMDZUMTI6MzY6MzguNTY3NzI5Ciog'
b'SU1BR0VfRElTUExBWV9VUkw6IE5vbmUKKiBJRDogNjA3YmJhZGMtMjVmOS00YjNjLWFmMTMtOTYz'
b'ZmRmOWMwN2UxCiogU1lTQURNSU46IEZhbHNlCiogQUNUSVZJVFlfU1RSRUFNU19FTUFJTF9OT1RJ'
b'RklDQVRJT05TOiBGYWxzZQoqIFNUQVRFOiBhY3RpdmUKKiBJTUFHRV9VUkw6IE5vbmUKKiBGVUxM'
b'TkFNRTogVG9tZWsKKiBFTUFJTDogdG9tZWsrMkBmamVsbHRvcHAub3JnCiogTlVNQkVSX0NSRUFU'
b'RURfUEFDS0FHRVM6IDAKCgpCZXN0IHJlZ2FyZHMsClRoZSBBSURTIERhdGEgUmVwb3NpdG9yeSBB'
b'ZG1pbmlzdHJhdG9yCgoKVGhpcyBpcyBhbiBhdXRvbWF0aWNhbGx5IGdlbmVyYXRlZCBlLW1haWws'
b'IHBsZWFzZSBkbyBub3QgcmVwbHkgdG8gaXQuCgpNZXNzYWdlIHNlbnQgZnJvbSBUaGUgQUlEUyBE'
b'YXRhIFJlcG9zaXRvcnkgKGh0dHA6Ly9ja2FuOjUwMDApCg=='
------------ END MESSAGE ------------

```