### PR TITLE
DB setup and test data commands wait for ckan to initialize.

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -142,6 +142,7 @@ def setup(args, extra):
 
 
 def init_ckan_db(args, extra):
+    call_command(["docker exec -it ckan /wait-for-it.sh ckan:5000 --timeout=0 -- echo 'CKAN ready'"])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini db init'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan-paster --plugin=ckanext-ytp-request initdb -c /etc/ckan/ckan.ini'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan-paster --plugin=ckanext-harvest harvester initdb -c /etc/ckan/ckan.ini'])
@@ -154,6 +155,7 @@ def init_ckan_db(args, extra):
 
 
 def load_demo_data(args, extra):
+    call_command(["docker exec -it ckan /wait-for-it.sh ckan:5000 --timeout=0 -- echo 'CKAN ready'"])
     import util.ckan_loader as loader
     loader.load_data("http://ckan:5000", ADMIN_APIKEY)
 


### PR DESCRIPTION
You can now run `adx dbsetup` and `adx demodata` commands immediately after `adx up`.
The setup commands will wait for the ckan:5000 to init.

![image](https://user-images.githubusercontent.com/30174560/98811264-da013e00-2420-11eb-9069-b7687e6f5af2.png)

```
➜  adx activate
(venv) ➜  adx adx up
sh -c "docker-compose up -d"
WARNING: The CKAN_SITE_URL variable is not set. Defaulting to a blank string.
WARNING: The CKAN_SMTP_USER variable is not set. Defaulting to a blank string.
WARNING: The CKAN_SMTP_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The ADX_SYSADMIN_API_KEY variable is not set. Defaulting to a blank string.
Creating network "adx_develop_default" with the default driver
Creating volume "adx_develop_ckan_storage" with default driver
Creating volume "adx_develop_pg_data" with default driver
Creating solr       ... done
Creating cron       ... done
Creating db         ... done
Creating datapusher ... done
Creating redis      ... done
Creating ckan       ... done
Creating supervisor ... done
(venv) ➜  adx adx dbsetup && adx demodata
docker exec -it ckan /wait-for-it.sh ckan:5000 --timeout=0 -- echo 'CKAN ready'
wait-for-it.sh: waiting for ckan:5000 without a timeout
wait-for-it.sh: ckan:5000 is available after 58 seconds
CKAN ready
docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini db init
```