### PR TITLE
ADX-511 Increase max number of rows for validation.

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -123,7 +123,7 @@ ckanext.validation.schema_directory = /usr/lib/adx/unaids_data_specifications/ta
 ckanext.validation.run_on_create_sync = True
 ckanext.validation.run_on_update_sync = True
 ckanext.validation.allow_invalid_data = True
-ckanext.validation.default_validation_options = {"row_limit": 5000, "error_limit": 100, "skip_checks": ["extra-header"] }
+ckanext.validation.default_validation_options = {"row_limit": 20000, "error_limit": 100, "skip_checks": ["extra-header"] }
 ckanext.validation.formats = csv xlsx xls shp geojson
 ckanext.validation.allow_invalid_data = True
 
@@ -145,7 +145,7 @@ ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.type = redis
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
-ckan.views.default_views = pdf_view image_view text_view geojson_view unaids_recline_view 
+ckan.views.default_views = pdf_view image_view text_view geojson_view unaids_recline_view
 
 # Customize which text formats the text_view plugin will show
 ckan.preview.json_formats = json


### PR DESCRIPTION
Ghana's population data is a whopping 18837 rows long. 