### PR TITLE
ADX-513 Set the limits for the organization list action

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -179,6 +179,9 @@ googleanalytics.id = NO_ID_FOR_DEVELOPEMENT
 #licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
 # ckan.template_footer_end =
 
+## Default limits
+ckan.group_and_organization_list_all_fields_max = 1000
+ckan.group_and_organization_list_max = 1000
 
 ## Internationalisation Settings
 ckan.locale_default = en
@@ -187,7 +190,6 @@ ckan.locales_offered = en fr
 ckan.locales_filtered_out = en_GB
 
 ## Feeds Settings
-
 ckan.feeds.authority_name =
 ckan.feeds.date =
 ckan.feeds.author_name =


### PR DESCRIPTION
organization_list action has a configurable limit.  It can be set both in the params of the action, and in the ckan config file.  I have decided to set both to a high number 1000, so that we don’t get silent clipping of the list.  I have set both the action param and the ckan config values for readability of the code and to ensure there is no silent clipping of the organization list anywhere else in the system. 

What are the implications of this? In what situations would it be important to clip the list?