### PR TITLE
Fixed favicon url

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -161,7 +161,7 @@ ckan.site_title = The AIDS Data Repository
 ckan.site_logo = /adr_simple.png
 ckan.site_description = Tools to streamline the process of managing and sharing HIV data.
 ckan.featured_orgs = malawi-moh zambia-moh
-ckan.favicon = favicon.ico
+ckan.favicon = /favicon.ico
 
 ckan.gravatar_default = identicon
 ckan.preview.direct = png jpg gif


### PR DESCRIPTION
# Problem
- The favicon fails to load on `/dataset`
- It references `/dataset/favicon.ico` rather than `/favicon.ico`
- [Other people have also come across this issue](https://stackoverflow.com/questions/34147672/how-to-change-favicon-in-ckan#comment95584515_34170640)

# Solution
- Prefix favicon with a `/` to reset the path back to the root domain rather than the current directory you're on

![image](https://user-images.githubusercontent.com/2634482/100080438-c224b380-2e3d-11eb-93ab-773d6ed7475b.png)
