### PR TITLE
Pytest as the default and only test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,20 @@ Now let's make the extension do something
 - Save `<h1>Hello World!</h1>` to it
 - Run another `adx build ckan; adx up` and your browser should display `Hello World!`
 - Read the [docs](https://docs.ckan.org/en/2.9/theming/templates.html#customizing-ckan-s-templates) for more info
+
+# Setting up production deployments
+1. Configure `ADX_PATH` env in your `.bashrc`, e.g.
+    ```
+    export ADX_PATH=$HOME/fjelltopp/adr
+    ```
+2. Clone the following additional repos into your `ADX_PATH`:
+    ```
+    git clone git@github.com:fjelltopp/adx_deploy.git
+    git clone git@github.com:fjelltopp/adx_manifest.git
+    ```
+3. Now you should be able to use the following command to draft PRs for prod deployment
+
+    Note: This only works with google chrome.
+    ```
+    adx deploy
+    ```

--- a/adx
+++ b/adx
@@ -187,8 +187,6 @@ actions['test'] = subparsers.add_parser(
 actions['test'].set_defaults(func=util.run_tests)
 actions['test'].add_argument('extension', metavar='name', type=str,
                              help='The extension name e.g."validation", "ytp-request"')
-actions['test'].add_argument('-p', '--pytest',  action='store_true',
-                             help='Use pytest instead of nosetest')
 
 parser.add_argument(
     "-log",

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -192,22 +192,13 @@ def run_tests(args, extra):
     extension_name = "ckanext-" + args.extension
     extension_path = "/usr/lib/adx/" + extension_name
     extension_sub_path = "/".join(extension_name.split("-"))
-    if args.pytest:
-        call_command([
-            f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
-            f'ckan /usr/local/bin/ckan-pytest --disable-warnings'
-            f' --ckan-ini={extension_path}/test.ini'
-            f' {extension_path}/{extension_sub_path}/tests '
-            f'--log-level=WARNING'
-        ] + extra)
-    else:
-        call_command([
-            f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
-            f'ckan /usr/local/bin/ckan-nosetests --ckan'
-            f' --with-pylons={extension_path}/test.ini'
-            f' {extension_path}/{extension_sub_path}/tests '
-            f'--logging-level=WARNING'
-        ] + extra)
+    call_command([
+        f'docker exec -e CKAN_SQLALCHEMY_URL={CKAN_TEST_SQLALCHEMY_URL} '
+        f'ckan /usr/local/bin/ckan-pytest --disable-warnings'
+        f' --ckan-ini={extension_path}/test.ini'
+        f' {extension_path}/{extension_sub_path}/tests '
+        f'--log-level=WARNING'
+    ] + extra)
 
 
 def deploy_master(args, extra):


### PR DESCRIPTION
Since upgrade to 2.9 pytest is the only way to run the tests. Neither of our extensions support nosetest anymore.