### PR TITLE
Adx 573 Use NGINX to proxy pass to giftless 

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -56,7 +56,7 @@ ckan.datastore.default_fts_index_method = gist
 
 ## Site Settings
 
-ckan.site_url = http://ckan:5000
+ckan.site_url = http://ckan
 #ckan.use_pylons_response_cleanup_middleware = true
 
 ## Authorization Settings
@@ -120,7 +120,7 @@ ckan.plugins = unaids emailasusername restricted authz_service package_versionin
 
 ckanext.versioning.backend_type = filesystem
 ckanext.versioning.backend_config = {"uri":"/var/lib/ckan/metastore"}
-ckanext.external_storage.storage_service_url=http://172.17.0.1:6001
+ckanext.external_storage.storage_service_url=http://ckan/giftless
 
 
 ckanext.authz_service.jwt_private_key = -----BEGIN RSA PRIVATE KEY-----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,4 +145,3 @@ services:
     depends_on:
       - ckan
       - giftless
-    hostname: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   pg_data:
 
 services:
+
   ckan:
     container_name: ckan
     build:
@@ -133,3 +134,15 @@ services:
     volumes:
       - ./giftless/giftless.yaml:/app/giftless.yaml
     command: ["--http", "0.0.0.0:6001", "-M", "-T", "--threads", "2", "-p", "2", "--manage-script-name", "--callable", "app"]
+
+  nginx:
+    container_name: nginx
+    image: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - "./nginx/nginx.conf:/etc/nginx/nginx.conf"
+    depends_on:
+      - ckan
+      - giftless
+    hostname: nginx

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://ckan:5000/;
+        }
+        location /giftless {
+            proxy_pass http://giftless:6001/;
+        }
+    }
+}


### PR DESCRIPTION
I found some CORS settings in the adx_config.ini file. Was considering it as a more lightweight solution to the problem, but then it wouldn't work for Manoj's remote dev env.  So I still believe an NGINX container is the right way to go.  It's more scale-able and flexible for further development, and also aligns the dev a little bit more with production. It's also not a particularly massive or complex codebase change.

The below is tested locally and appears to work fine. 

**Was there any particular reason to access ckan on port 5000, or are we happy to access on port 80 as configured here?** 
