### PR TITLE
ADX-573 Use http://adr domain for dev env.

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -56,7 +56,7 @@ ckan.datastore.default_fts_index_method = gist
 
 ## Site Settings
 
-ckan.site_url = http://ckan
+ckan.site_url = http://adr
 #ckan.use_pylons_response_cleanup_middleware = true
 
 ## Authorization Settings
@@ -120,7 +120,7 @@ ckan.plugins = unaids emailasusername restricted authz_service package_versionin
 
 ckanext.versioning.backend_type = filesystem
 ckanext.versioning.backend_config = {"uri":"/var/lib/ckan/metastore"}
-ckanext.external_storage.storage_service_url=http://ckan/giftless
+ckanext.external_storage.storage_service_url=http://adr/giftless
 
 
 ckanext.authz_service.jwt_private_key = -----BEGIN RSA PRIVATE KEY-----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,3 +146,7 @@ services:
       - ckan
       - giftless
     hostname: adr
+    networks:
+      default:
+        aliases:
+          - adr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,3 +145,4 @@ services:
     depends_on:
       - ckan
       - giftless
+    hostname: adr

--- a/giftless/giftless.yaml
+++ b/giftless/giftless.yaml
@@ -5,3 +5,9 @@ TRANSFER_ADAPTERS:
       storage_class: giftless.storage.local_storage:LocalStorage
 AUTH_PROVIDERS:
   - giftless.auth.allow_anon:read_write
+MIDDLEWARE:
+  - class: werkzeug.middleware.proxy_fix:ProxyFix
+    kwargs:
+      x_host: 1
+      x_port: 1
+      x_prefix: 1

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,13 @@ http {
         server_name adr;
         listen 80;
         location / {
+            add_header X-Proxy-Cache $upstream_cache_status;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Prefix /;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
             proxy_pass http://ckan:5000/;
         }
         location /giftless/ {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,8 +8,10 @@ http {
         location / {
             proxy_pass http://ckan:5000/;
         }
-        location /giftless {
+        location /giftless/ {
             proxy_pass http://giftless:6001/;
+            proxy_set_header X-Forwarded-Prefix /giftless;
+            proxy_set_header X-Forwarded-Host adr;
         }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,14 +4,20 @@ events {
 
 http {
     server {
+        server_name adr;
         listen 80;
         location / {
             proxy_pass http://ckan:5000/;
         }
         location /giftless/ {
-            proxy_pass http://giftless:6001/;
+            add_header X-Proxy-Cache $upstream_cache_status;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Prefix /giftless;
-            proxy_set_header X-Forwarded-Host adr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_pass http://giftless:6001/;
         }
     }
 }


### PR DESCRIPTION
This commit wraps up my solution to the problems serving the giftless api to both ckan frontend and backend simultaneously. 

1. Rename the domain of the dev env from http://ckan to http://adr (could easily choose something else if needbe) in the /etc/hosts file, to avoid conflicts with the ckan container hostname.
2. In the docker-compose file set the network alias attribute of the nginx container to also be adr
3. In the adx_config.ini file set the ckan.site_url to be http://adr/ and the ckanext.external_storage.storage_service_url to be http://adr/giftless

The result is that http://adr/ directs to the nginx container, which can then route traffic, whether called from within the docker network or from the host.

This would require everyone updating their hosts file.  It might be possible to avoid this by giving the ckan hostname to the nginx container and inventing a new hostname for the ckan container. But then it becomes more confusing I think.  Really, wherever possible, the hostname should match the container name, which should match the service name, which should describe the software service being run.

I'm proposing that nginx is the only exception and that we should set it's hostname to match the domain we give to the dev env, i.e. whatever value is set in the /etc/hosts file and the ckan.site_url and ckanext.external_storage.storage_service_url  fields of the adx_config.ini file.

The commit also includes the fix recommended by datopian [here](https://github.com/datopian/giftless#fixing-generated-urls-when-running-behind-a-proxy) when running giftless behind a reverse proxy. 