### PR TITLE
ADX-577 Simple JWT based authentication for Giftless.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,8 +134,10 @@ services:
     image: datopian/giftless
     environment:
       - GIFTLESS_CONFIG_FILE=/app/giftless.yaml
+      - GIFTLESS_DEBUG=1
     volumes:
       - ./giftless/giftless.yaml:/app/giftless.yaml
+      - ./ckan/jwt_public_key.pem:/app/jwt_public_key.pem
     command: ["--http", "0.0.0.0:6001", "-M", "-T", "--threads", "2", "-p", "2", "--manage-script-name", "--callable", "app"]
 
   nginx:

--- a/giftless/giftless.yaml
+++ b/giftless/giftless.yaml
@@ -4,7 +4,10 @@ TRANSFER_ADAPTERS:
     options:
       storage_class: giftless.storage.local_storage:LocalStorage
 AUTH_PROVIDERS:
-  - giftless.auth.allow_anon:read_write
+  - factory: giftless.auth.jwt:factory
+    options:
+      algorithm: RS256
+      public_key_file: /app/jwt_public_key.pem
 MIDDLEWARE:
   - class: werkzeug.middleware.proxy_fix:ProxyFix
     kwargs:


### PR DESCRIPTION
There are no docs on this in the datopian repo, but I believe I have unravelled the code. 

The configuration appears to work with adr dev env running ckanext-authz-service:

- The giftless debug logs correctly identify the ckan user
- Changing the public key in giftless (so that it doesn't match authz-service's private key) breaks authentication
- Trying to perform giftless write actions with an ckan user who doesn't have write access gets 403 forbidden response from giftless

I wonder though whether we should put this on a short list of code pieces that we want datopian folks to sanity check at some point? It's quite important to get security right. 



