### PR TITLE
ADX-604 Switch Beaker to Redis session storage, TTL set to 24 hours

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -27,7 +27,8 @@ full_stack = true
 cache_dir = /tmp/%(ckan.site_id)s/
 beaker.session.key = ckan
 beaker.session.type = ext:redis
-beaker.session.url = redis://redis:6379/6
+beaker.session.url = redis://redis:6379/3
+# set session timeout to 24 hours
 beaker.session.cookie_expires = 86400
 beaker.session.timeout = 86400
 
@@ -148,6 +149,9 @@ ckanext.pages.blog = False
 
 ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.type = redis
+ckan.harvest.mq.port=6379
+ckan.harvest.mq.redis_db=2
+
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
 ckan.views.default_views = pdf_view image_view text_view geojson_view unaids_recline_view

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -26,6 +26,10 @@ use = egg:ckan
 full_stack = true
 cache_dir = /tmp/%(ckan.site_id)s/
 beaker.session.key = ckan
+beaker.session.type = ext:redis
+beaker.session.url = redis://redis:6379/6
+beaker.session.cookie_expires = 86400
+beaker.session.timeout = 86400
 
 # This is the secret token that the beaker library uses to hash the cookie sent
 # to the client. `ckan generate config` generates a unique value for this each


### PR DESCRIPTION
To test connect to your Redis instance, e.g. `docker exec -it redis sh`, run redis-cli, select database 6 and list session keys and get TTL for any of the sessions
```
docker exec -it redis sh
redis-cli
127.0.0.1:6379> select 6
127.0.0.1:6379[6]> keys *
1) "beaker_cache:5f46010df3264da48da588104686176a:session"
127.0.0.1:6379[6]> ttl "beaker_cache:5f46010df3264da48da588104686176a:session"
(integer) 86497
```
