### PR TITLE
Docker images feature branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Docker-compose
    pip3 install --user -r ./adx_develop/requirements.txt
    ```
 
-2. Add ckan as localhost name to `/etc/hosts`. After the addition the file should look something like
+2. Add dev-adr as localhost name to `/etc/hosts`. After the addition the file should look something like
    ```
    127.0.0.1       localhost
-   127.0.1.1       somehostname
-   127.0.0.1       ckan
+   127.0.0.1       dev-adr
    ```
 
 3. Add a sym link to the dev env script from your $PATH:
@@ -45,7 +44,13 @@ Docker-compose
    This shorthand sript can now be used from anywhere in your file system to
    issue a command to the adx development environment. Run `adx -h` for more
    information.
-
+   
+3. Environment variables configuration:
+   Clone the template `dev.env` file to `.env` where you can tweak the configuration:
+   ```
+   cp adx_develop/dev.env adx_develop/.env
+   ```
+   
 4. Setup the ADX code base.
    ```
    adx setup
@@ -104,7 +109,20 @@ sudo apt-get install libpq-dev
 adx_develop/util/install_requirements.sh
 ```
 
+## Docker images for feature branches
 
+New feature which require changes to docker images can create problems
+when switching from feature-branch work back to development (to work
+on important bug fixes, reviewing PRs etc.)
+
+In `.env` you can change the value of:
+```bash
+IMAGE_TAG=development
+```
+to a custom value representing your feature branch, e.g. `'versioning'`
+to be able to quickly switch between different ADR versions. That way
+after switching to a different git branch you won't have to rebuild all
+of the images.
 
 ## Resetting the code base
 
@@ -112,13 +130,9 @@ The adx script comes with a convienience command forall that enables you to quic
 The command can be used to reset your code base once everything you want to keep is committed and ideally pushed.
 
 ```
+adx sync
 adx forall -c git checkout development
 adx forall -c git pull --rebase --preserve-merges
-```
-
-Occasionally new repo's might be added to the code base, so once you have a clean codebase run the following command to check for and pull new repos.
-```
-adx sync
 ```
 
 ## Using a fake SMTP server

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ adx forall -c git pull --rebase --preserve-merges
 
 ## Using a fake SMTP server
 
-We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr" as a host name you can access at http://adr:5555/
+We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr" as a host name you can access at http://dev-adr:5555/
 
 ## Running CKAN tests locally
 

--- a/dev.env
+++ b/dev.env
@@ -2,27 +2,10 @@
 # Save a copy of this file as .env and insert your own values.
 # Verify correct substitution with "docker-compose config"
 # If variables are newly added or enabled, please delete and rebuild the images to pull in changes:
-# docker-compose down
-# docker rmi -f docker_ckan docker_db
-# docker rmi $(docker images -f dangling=true -q)
-# docker-compose build
-# docker-compose up -d
-# docker-compose restart ckan # give the db service time to initialize the db cluster on first run
-
+#
 # Image: ckan
 CKAN_SITE_ID=default
-#
-# On AWS, your CKAN_SITE_URL is the output of:
-# curl -s http://169.254.169.254/latest/meta-data/public-hostname
-# CKAN_SITE_URL=http://ec2-xxx-xxx-xxx-xxx.ap-southeast-2.compute.amazonaws.com
-# On OSX with Docker for Mac, your CKAN_SITE_URL is
-# CKAN_SITE_URL=http://docker.for.mac.localhost:5000
-# When running locally, CKAN_SITE_URL must contain the port
-CKAN_SITE_URL=http://ckan:5000
-#
-# CKAN_PORT must be available on the host: sudo netstat -na
-# To apply change: docker-compose down && docker rmi docker_ckan && docker-compose build ckan
-CKAN_PORT=5000
+CKAN_SITE_URL=http://dev-adr
 #
 # Email settings
 CKAN_SMTP_SERVER=email-smtp.eu-west-1.amazonaws.com:25
@@ -42,5 +25,9 @@ POSTGRES_PORT=5432
 # Readwrite user/pass will be ckan:POSTGRES_PASSWORD
 # Readonly user/pass will be datastore_ro:DATASTORE_READONLY_PASSWORD
 DATASTORE_READONLY_PASSWORD=datastore
-
-ADX_PATH=/home/tomek/work/fjelltopp/adx
+#
+# Fjelltopp custom variables
+ADX_PATH=${HOME}/work/fjelltopp/adx
+GIFTLESS_AWS_ACCESS_KEY_ID=XXX
+GIFTLESS_AWS_SECRET_ACCESS_KEY=YYY
+IMAGE_TAG=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ volumes:
 services:
   ckan:
     container_name: ckan
+    image: adr.ckan:${IMAGE_TAG}
     build:
       context: ../
       dockerfile: adx_develop/ckan/Dockerfile
@@ -47,6 +48,7 @@ services:
 
   supervisor:
     container_name: supervisor
+    image: adr.supervisor:${IMAGE_TAG}
     build:
       context: ../
       dockerfile: adx_develop/ckan/Dockerfile
@@ -72,6 +74,7 @@ services:
 
   cron:
     container_name: cron
+    image: adr.cron:${IMAGE_TAG}
     build: cron
     environment:
       # Set the ADX_SYSADMIN_API_KEY env var on the host to auto send emails
@@ -81,9 +84,10 @@ services:
       - ../ckan:/usr/lib/ckan/venv/src/ckan
 
   datapusher:
+    container_name: datapusher
+    image: adr.datapusher:${IMAGE_TAG}
     build:
       context: ../datapusher
-    container_name: datapusher
     volumes:
       - ../datapusher:/var/www/datapusher
     ports:
@@ -95,6 +99,7 @@ services:
     container_name: db
     ports:
       - "5432:5432"
+    image: adr.db:${IMAGE_TAG}
     build:
       context: ../ckan/
       dockerfile: contrib/docker/postgresql/Dockerfile
@@ -111,6 +116,7 @@ services:
     container_name: solr
     ports:
       - "8983:8983"
+    image: adr.solr:${IMAGE_TAG}
     build:
       context: .
       dockerfile: solr/Dockerfile
@@ -124,7 +130,7 @@ services:
     ports:
       - "6379:6379"
     image: redis:latest
- 
+
   smtp:
     container_name: smtp
     image: rnwood/smtp4dev:v3

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -10,7 +10,10 @@ SUDO = os.environ.get('ADX_SUDO', '')
 
 compose = ["docker-compose"]
 
-COMPOSE_PATH = os.path.abspath(os.path.dirname(__file__))
+COMPOSE_PATH = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    '..'
+)
 
 ADX_MANIFEST_URL = os.environ.get(
     'ADX_MANIFEST_URL',
@@ -149,6 +152,7 @@ def init_ckan_db(args, extra):
     call_command(['docker exec -it ckan /usr/local/bin/ckan-paster --plugin=ckanext-validation validation init-db -c /etc/ckan/ckan.ini'])
 
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini datastore set-permissions | docker exec -i db psql -U ckan'])
+    call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini versions initdb'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini user add admin email=admin@localhost name=admin fullname=Admin password=fjelltopp apikey=a4bf5640-e1b2-4141-8c22-f2b96b6df2c3'])
     call_command([f'docker exec db psql -U {PG_USER} -c "UPDATE public.user SET apikey = \'{ADMIN_APIKEY}\' WHERE name = \'admin\';"'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini sysadmin add admin'])


### PR DESCRIPTION
This PR adds:
1. Docker images for ADR images to make switching between feature branches easier
2. Changes the hostname from `adr` to `dev-adr` to avoid confusion from ADR production URL