### PR TITLE
ADX-595 Upgrade authz-service and blob-storage versions.

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -70,9 +70,11 @@ RUN ckan-pip install -e "git+https://github.com/ckan/ckanext-spatial.git@ce4f03b
 RUN ckan-pip install -e "git+https://github.com/EnviDat/ckanext-composite.git@23a060b03d2432a58cc66968d93a15f5f1654055#egg=ckanext-composite"
 RUN ckan-pip install -e "git+https://github.com/open-data/ckanext-repeating.git@291295557ff74b26784f6271c1a1b4ffdb990f43#egg=ckanext-repeating"
 RUN ckan-pip install -e "git+https://github.com/okfn/ckanext-sentry@d3b1d1cf1f975b3672891012e6c75e176497db8f#egg=ckanext-sentry"
-RUN ckan-pip install -e "git+https://github.com/datopian/ckanext-authz-service@v0.1.4#egg=ckanext-authz-service"
-RUN ckan-pip install -e "git+https://github.com/datopian/ckanext-blob-storage@v0.6.0#egg=ckanext-external-storage" && \
-    ckan-pip install -r "https://raw.githubusercontent.com/datopian/ckanext-blob-storage/v0.6.0/requirements.py2.txt"
+# using unreleased version with a fix for https://github.com/datopian/ckanext-authz-service/issues/24
+RUN ckan-pip install -e "git+https://github.com/datopian/ckanext-authz-service@bd4c80f55a714c1117a0e130d07463e383c494c7#egg=ckanext-authz-service"
+# using fjelltopp fork untill https://github.com/datopian/ckanext-blob-storage/pull/59 is merged
+#RUN ckan-pip install -e "git+https://github.com/datopian/ckanext-blob-storage@v0.6.0#egg=ckanext-external-storage" && \
+#    ckan-pip install -r "https://raw.githubusercontent.com/datopian/ckanext-blob-storage/v0.6.0/requirements.py2.txt"
 
 # Install requirements for extensions with a local source
 COPY ./ckanext-scheming/requirements.txt /usr/lib/ckan/scheming-requirements.txt
@@ -101,6 +103,12 @@ RUN ckan-pip install -r /usr/lib/ckan/restricted-requirements.txt
 
 COPY ./ckanext-unaids/requirements.txt /usr/lib/ckan/unaids-requirements.txt
 RUN ckan-pip install -r /usr/lib/ckan/unaids-requirements.txt
+
+COPY ./ckanext-blob-storage/requirements.py2.txt /usr/lib/ckan/blob-storage-requirements.txt
+RUN ckan-pip install -r /usr/lib/ckan/blob-storage-requirements.txt
+
+COPY ./ckanext-authz-service/requirements.py2.txt /usr/lib/ckan/authz-service-requirements.txt
+RUN ckan-pip install -r /usr/lib/ckan/authz-service-requirements.txt
 
 RUN rm /usr/lib/ckan/*-requirements.txt
 

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -121,13 +121,13 @@ ckan.redis.url = redis://redis:6379/1
 #		Add ``resource_proxy`` to enable resorce proxying and get around the
 #		same origin policy
 # Note: Plugins to the left take precendence over plugins to the right!!! Opposite to what you might expect.
-ckan.plugins = unaids scheming_datasets external_storage emailasusername restricted authz_service stats
+ckan.plugins = unaids scheming_datasets blob_storage emailasusername restricted authz_service stats
   text_view image_view unaids_recline_view recline_graph_view recline_map_view recline_grid_view
   resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest
 
-ckanext.external_storage.storage_service_url=http://dev-adr/giftless
-ckanext.external_storage.use_scheming_file_uploader=True
+ckanext.blob_storage.storage_service_url=http://dev-adr/giftless
+ckanext.blob_storage.use_scheming_file_uploader=True
 
 
 ckanext.authz_service.jwt_private_key = -----BEGIN RSA PRIVATE KEY-----

--- a/ckan/ckan-entrypoint-adx.sh
+++ b/ckan/ckan-entrypoint-adx.sh
@@ -78,6 +78,7 @@ ckan-pip install -e /usr/lib/adx/ckanext-harvest
 ckan-pip install -e /usr/lib/adx/ckanext-geoview
 ckan-pip install -e /usr/lib/adx/ckanext-pdfview
 ckan-pip install --no-deps -e /usr/lib/adx/ckanext-emailasusername
+ckan-pip install --no-deps -e /usr/lib/adx/ckanext-blob-storage
 
 # build js components & allow editing
 yarn --cwd /usr/lib/adx/ckanext-unaids/ckanext/unaids/react/


### PR DESCRIPTION
After some work I have managed to upgrade ADR to latest authz-service and blob-storage. I've submited 3 PR for your review - I was just too tired to give them a descent description, sorry! I'm happy to walk you through it tomorrow morning.

    Only latest unreleased master authz-service includes a fix for ckan context and our giftless support in ckan actions
    blob-storage does not yet support that fresh authz-service from 1), I needed to fork v0.8.0 and push it to fjelltopp/ckanext-blob-storage@development (I've notified datiopian about needed changes to hopefully it's just a temp solution)
    I've updated adx_develop and adx_deploy according to 1) & 2)