### PR TITLE
Change ADR dev domain to adr.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Docker-compose
    pip3 install --user -r ./adx_develop/requirements.txt
    ```
 
-2. Add dev-adr as localhost name to `/etc/hosts`. After the addition the file should look something like
+2. Add adr.local as localhost name to `/etc/hosts`. After the addition the file should look something like
    ```
    127.0.0.1       localhost
-   127.0.0.1       dev-adr
+   127.0.0.1       adr.local
    ```
 
 3. Add a sym link to the dev env script from your $PATH:
@@ -95,7 +95,7 @@ Docker-compose
    adx demodata
    ```
 
-9. CKAN should be available at http://dev-adr/
+9. CKAN should be available at http://adr.local/
 
 ### [OPTIONAL] Setting up local ckan dev venv
 1. For Ubuntu you'll need to satisfy psycopg2:
@@ -137,7 +137,7 @@ adx forall -c git pull --rebase --preserve-merges
 
 ## Using a fake SMTP server
 
-We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr" as a host name you can access at http://dev-adr:5555/
+We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr" as a host name you can access at http://adr.local:5555/
 
 ## Running CKAN tests locally
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ adx forall -c git pull --rebase --preserve-merges
 
 ## Using a fake SMTP server
 
-We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr" as a host name you can access at http://adr.local:5555/
+We're using https://github.com/rnwood/smtp4dev to "fake" an SMTP service, it's deployed as part of docker compose - smtp container. It catches all the emails sent to it, accepts any credentials. Emails can be viewed via a web console available at port 5555, so if your local environment uses "adr.local" as a host name you can access at http://adr.local:5555/
 
 ## Running CKAN tests locally
 

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -126,7 +126,7 @@ ckan.plugins = unaids scheming_datasets blob_storage emailasusername restricted 
   resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest versions
 
-ckanext.blob_storage.storage_service_url=http://dev-adr/giftless
+ckanext.blob_storage.storage_service_url=http://adr.local/giftless
 ckanext.blob_storage.use_scheming_file_uploader=True
 
 

--- a/demo_data/organizations.json
+++ b/demo_data/organizations.json
@@ -17,7 +17,7 @@
       ],
       "display_name": "Fjelltopp",
       "description": "Fjelltopp demo organization",
-      "image_url": "http://dev-adr/fjelltopp.png",
+      "image_url": "http://adr.local/fjelltopp.png",
       "name": "fjelltopp",
       "state": "active",
       "title": "Fjelltopp"

--- a/dev.env
+++ b/dev.env
@@ -4,7 +4,7 @@
 # If variables are newly added or enabled, please delete and rebuild the images to pull in changes:
 #
 # Image: ckan
-ADR_HOSTNAME=dev-adr
+ADR_HOSTNAME=adr.local
 CKAN_SITE_ID=default
 CKAN_SITE_URL=http://${ADR_HOSTNAME}
 #

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
     server {
-        server_name adr;
+        server_name adr.local;
         listen 80;
         client_max_body_size 1G;
         location / {

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -26,7 +26,7 @@ ADX_PATH = os.path.expanduser(os.environ.get(
 PG_USER = os.environ.get('PG_USER', 'ckan')
 CKAN_TEST_SQLALCHEMY_URL = os.environ.get("CKAN_TEST_SQLALCHEMY_URL", "postgresql://ckan_default:pass@db/ckan_test")
 ADMIN_APIKEY = os.environ.get("ADMIN_APIKEY", "6011357f-a7f8-4367-a47d-8c2ab8059520")
-CKAN_SITE_URL = os.environ.get("CKAN_SITE_URL", "http://dev-adr")
+CKAN_SITE_URL = os.environ.get("CKAN_SITE_URL", "http://adr.local")
 
 def call_command(args):
     """

--- a/util/ckan_loader.py
+++ b/util/ckan_loader.py
@@ -150,4 +150,4 @@ def load_data(adr_url, apikey):
 
 
 if __name__ == '__main__':
-    load_data('http://dev-adr', "6011357f-a7f8-4367-a47d-8c2ab8059520")
+    load_data('http://adr.local', "6011357f-a7f8-4367-a47d-8c2ab8059520")


### PR DESCRIPTION
dev-adr doesn't look like a fqdn to most browsers, using something like adr.local should cause less issues and usually won't require prefixing it with http:// 
This is a cosmetic change, but I think it makes sense, similar to ckan.minikube when we're using CKAN on Minikube or navigator.local in case of current Navigator dev env

Not sure why Nginx was using adr instead of dev-adr, it probably worked because adr was the only vhost