### PR TITLE
Adx 714 guess format

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -63,6 +63,7 @@ ckan.datastore.default_fts_index_method = gist
 
 ckan.site_url = http://ckan:5000 # overwirtten by env var
 #ckan.use_pylons_response_cleanup_middleware = true
+ckan.resource_formats = /usr/lib/adx/ckanext-unaids/ckanext/unaids/resource_formats.json
 
 ## Authorization Settings
 
@@ -126,7 +127,7 @@ ckan.plugins = unaids scheming_datasets blob_storage emailasusername restricted 
   resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest versions
 
-ckanext.blob_storage.storage_service_url=http://dev-adr/giftless
+ckanext.blob_storage.storage_service_url=http://adr.local/giftless
 ckanext.blob_storage.use_scheming_file_uploader=True
 
 

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -126,7 +126,7 @@ ckan.plugins = unaids scheming_datasets blob_storage emailasusername restricted 
   resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest versions
 
-ckanext.blob_storage.storage_service_url=http://adr.local/giftless
+ckanext.blob_storage.storage_service_url=http://dev-adr/giftless
 ckanext.blob_storage.use_scheming_file_uploader=True
 
 
@@ -171,10 +171,10 @@ ckanext.validation.formats = csv xlsx xls shp geojson
 
 scheming.dataset_schemas_directory = /usr/lib/adx/unaids_data_specifications/package_schemas
 
-scheming.presets = ckanext.scheming:presets.json
+scheming.presets = ckanext.unaids:presets.json
+                   ckanext.scheming:presets.json
                    ckanext.repeating:presets.json
                    ckanext.composite:presets.json
-                   ckanext.unaids:presets.json
                    ckanext.validation:presets.json
 
 emailasusername.search_by_username_and_email = True


### PR DESCRIPTION
The order of overriding presets happens in the oposite order to what I would expect; those that come last have least precedence. 

We definitely want all our unaids preset to override all others, so I have simply moved this to the top of the list.

We are also adding new resource formats (pjnz) in roder to do this properly we have to add the format to the resource_formats.json config file that ckan uses.  I have created an updated copy of the config in ckanext-unaids. 