### PR TITLE
ADX-279 Debug logger for dev env.

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -285,7 +285,7 @@ email_to = support@fjelltopp.org
 
 ## Logging configuration
 [loggers]
-keys = root, ckan, ckanext, ckanext_emailasusername, werkzeug
+keys = root, ckan, ckanext, ckanext_emailasusername, werkzeug, debug
 
 [handlers]
 keys = console
@@ -319,6 +319,12 @@ propagate = 0
 level = WARNING
 handlers = console
 qualname = ckanext
+propagate = 0
+
+[logger_debug]
+level = DEBUG
+handlers = console
+qualname = debug
 propagate = 0
 
 [handler_console]


### PR DESCRIPTION
Config for debug logger that can be used in production.