### PR TITLE
ADX-876 AUTH0 SSO PoC

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -76,10 +76,12 @@ ckanext-scheming = {editable = true, path = "../ckanext-scheming"}
 ckanext-unaids = {editable = true, path = "../ckanext-unaids"}
 ckanext-validation = {editable = true, path = "../ckanext-validation"}
 ckanext-blob-storage = {editable = true, path = "../ckanext-blob-storage"}
+ckanext-saml2auth = "==1.2.3"
+importlib-resources = "*"
 ckanext-fork = {editable = true, path = "../ckanext-fork"}
 ckan = {path = "../ckan",editable = true}
 cffi = "==1.14.5"
-cryptography = "==3.4.7"
+cryptography = "~=3.4.7"
 pycparser = "==2.20"
 typing-extensions = "==4.2.0"
 typing = "==3.7.4.3"
@@ -87,13 +89,13 @@ ckantoolkit = ">=0.0.3"
 geoalchemy = ">=0.6"
 geoalchemy2 = "==0.5.0"
 shapely = ">=1.2.13"
-pyproj = "==2.6.1"
+pyproj = "~=2.6.1"
 argparse = "*"
 pyparsing = ">=2.1.10"
 python-slugify = "==4.0.0"
 pandas = ">=1.4.2"
 pika = ">=1.1.0"
-pyopenssl = "==18.0.0"
+pyopenssl = "~=18.0.0"
 pycountry = "==19.8.18"
 giftless-client = "==0.1.1"
 cssmin = "==0.2.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "680c3d852128495482a4acee03f29b017684b879dd19828b0a91a4311a96cfe8"
+            "sha256": "6f96a914e2af81b7cb1eb7bac82f0ede86cd5cc837ec944f6faf83653d9c863b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,19 +165,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:853cf4b2136c4deec4e01a17b89126377bfca30223535795d879ca65af4c4a69",
-                "sha256:a8ad13a23745b6d4a56d5bdde53a7a80cd7b40016cd411b9a94e6bbfb2ca5dd2"
+                "sha256:31c0adf71e4bd19a5428580bb229d7ea3b5795eecaa0847a85385df00c026116",
+                "sha256:4f493a2aed71cee93e626de4f67ce58dd82c0473480a0fc45b131715cd8f4f30"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.13"
+            "version": "==1.26.16"
         },
         "botocore": {
             "hashes": [
-                "sha256:9c73a180fad9a7da7797530ced3b5069872bff915b1ae9fa11fc1ed79b584c8e",
-                "sha256:9d39db398f472c0aa97098870c8c4cf12636b2667a18e694fea5fae046af907e"
+                "sha256:271b599e6cfe214405ed50d41cd967add1d5d469383dd81ff583bc818b47f59b",
+                "sha256:8cfcc10f2f1751608c3cec694f2d6b5e16ebcd50d0a104f9914d5616227c62e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.13"
+            "version": "==1.29.16"
         },
         "btrees": {
             "hashes": [
@@ -382,6 +382,14 @@
             "editable": true,
             "path": "./../ckanext-restricted"
         },
+        "ckanext-saml2auth": {
+            "hashes": [
+                "sha256:1b09140b55368079b3327021b21860a1c1c5dd26d0ad777477d0930ce2727f1b",
+                "sha256:7da4ce168a7f70c706923e518a4cb21a0a37cb432e72600d07a1a592c7b5a794"
+            ],
+            "index": "pypi",
+            "version": "==1.2.3"
+        },
         "ckanext-scheming": {
             "editable": true,
             "path": "./../ckanext-scheming"
@@ -412,6 +420,10 @@
             "editable": true,
             "path": "./../ckanext-ytp-request"
         },
+        "ckanext-ytp-request-request": {
+            "editable": true,
+            "path": "./../ckanext-ytp-request"
+        },
         "ckantoolkit": {
             "hashes": [
                 "sha256:72432c1a1c48b96a6ebc614f11fc2b9c3c27d7507dbbd35534068ef060a2c754"
@@ -435,23 +447,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d",
-                "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959",
-                "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6",
-                "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873",
-                "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2",
-                "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713",
-                "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
-                "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
-                "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
-                "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586",
-                "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3",
-                "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
-                "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
-                "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
+                "sha256:0a7dcbcd3f1913f664aca35d47c1331fce738d44ec34b7be8b9d332151b0b01e",
+                "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b",
+                "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7",
+                "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085",
+                "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc",
+                "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d",
+                "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a",
+                "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498",
+                "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89",
+                "sha256:8695456444f277af73a4877db9fc979849cd3ee74c198d04fc0776ebc3db52b9",
+                "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c",
+                "sha256:94fff993ee9bc1b2440d3b7243d488c6a3d9724cc2b09cdb297f6a886d040ef7",
+                "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb",
+                "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14",
+                "sha256:a305600e7a6b7b855cd798e00278161b681ad6e9b7eca94c721d5f588ab212af",
+                "sha256:cd65b60cfe004790c795cc35f272e41a3df4631e2fb6b35aa7ac6ef2859d554e",
+                "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5",
+                "sha256:d9ec0e67a14f9d1d48dd87a2531009a9b251c02ea42851c060b25c782516ff06",
+                "sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7"
             ],
             "index": "pypi",
-            "version": "==3.4.7"
+            "version": "==3.4.8"
         },
         "cssmin": {
             "hashes": [
@@ -473,6 +490,14 @@
                 "sha256:b8d2d605cfb5fed0da86f9ad64d0973c6f84b21939d49265e135811b33ee8113"
             ],
             "version": "==4.7"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
+                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.7.1"
         },
         "docopt": {
             "hashes": [
@@ -503,6 +528,14 @@
             ],
             "index": "pypi",
             "version": "==2.4.0"
+        },
+        "elementpath": {
+            "hashes": [
+                "sha256:6122419481a4c73101918714274b2cec907feecd04a44b623b4bae4292853328",
+                "sha256:cca18742dc0f354f79874c41a906e6ce4cc15230b7858d22a861e1ec5946940f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.0.2"
         },
         "et-xmlfile": {
             "hashes": [
@@ -704,6 +737,14 @@
                 "sha256:ff8cf7507d9d8939264068c2cff0a23f99703fa2f31eb3cb45a9a52798843586"
             ],
             "version": "==3.1.4"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668",
+                "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"
+            ],
+            "index": "pypi",
+            "version": "==5.10.0"
         },
         "isodate": {
             "hashes": [
@@ -991,36 +1032,36 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:04e51b01d5192499390c0015630975f57836cc95c7411415b499b599b05c0c96",
-                "sha256:05c527c64ee02a47a24031c880ee0ded05af0623163494173204c5b72ddce658",
-                "sha256:0a78e05ec09731c5b3bd7a9805927ea631fe6f6cb06f0e7c63191a9a778d52b4",
-                "sha256:17da7035d9e6f9ea9cdc3a513161f8739b8f8489d31dc932bc5a29a27243f93d",
-                "sha256:249cec5f2a5b22096440bd85c33106b6102e0672204abd2d5c014106459804ee",
-                "sha256:2c25e5c16ee5c0feb6cf9d982b869eec94a22ddfda9aa2fbed00842cbb697624",
-                "sha256:32e3d9f65606b3f6e76555bfd1d0b68d94aff0929d82010b791b6254bf5a4b96",
-                "sha256:36aa1f8f680d7584e9b572c3203b20d22d697c31b71189322f16811d4ecfecd3",
-                "sha256:5b0c970e2215572197b42f1cff58a908d734503ea54b326412c70d4692256391",
-                "sha256:5cee0c74e93ed4f9d39007e439debcaadc519d7ea5c0afc3d590a3a7b2edf060",
-                "sha256:669c8605dba6c798c1863157aefde959c1796671ffb342b80fcb80a4c0bc4c26",
-                "sha256:66a1ad667b56e679e06ba73bb88c7309b3f48a4c279bd3afea29f65a766e9036",
-                "sha256:683779e5728ac9138406c59a11e09cd98c7d2c12f0a5fc2b9c5eecdbb4a00075",
-                "sha256:6bb391659a747cf4f181a227c3e64b6d197100d53da98dcd766cc158bdd9ec68",
-                "sha256:81f0674fa50b38b6793cd84fae5d67f58f74c2d974d2cb4e476d26eee33343d0",
-                "sha256:927e59c694e039c75d7023465d311277a1fc29ed7236b5746e9dddf180393113",
-                "sha256:932d2d7d3cab44cfa275601c982f30c2d874722ef6396bb539e41e4dc4618ed4",
-                "sha256:a52419d9ba5906db516109660b114faf791136c94c1a636ed6b29cbfff9187ee",
-                "sha256:b156a971bc451c68c9e1f97567c94fd44155f073e3bceb1b0d195fd98ed12048",
-                "sha256:bcf1a82b770b8f8c1e495b19a20d8296f875a796c4fe6e91da5ef107f18c5ecb",
-                "sha256:cb2a9cf1150302d69bb99861c5cddc9c25aceacb0a4ef5299785d0f5389a3209",
-                "sha256:d8c709f4700573deb2036d240d140934df7e852520f4a584b2a8d5443b71f54d",
-                "sha256:db45b94885000981522fb92349e6b76f5aee0924cc5315881239c7859883117d",
-                "sha256:ddf46b940ef815af4e542697eaf071f0531449407a7607dd731bf23d156e20a7",
-                "sha256:e675f8fe9aa6c418dc8d3aac0087b5294c1a4527f1eacf9fe5ea671685285454",
-                "sha256:eb7e8cf2cf11a2580088009b43de84cabbf6f5dae94ceb489f28dba01a17cb77",
-                "sha256:f340331a3f411910adfb4bbe46c2ed5872d9e473a783d7f14ecf49bc0869c594"
+                "sha256:0183cb04a057cc38fde5244909fca9826d5d57c4a5b7390c0cc3fa7acd9fa883",
+                "sha256:1fc87eac0541a7d24648a001d553406f4256e744d92df1df8ebe41829a915028",
+                "sha256:220b98d15cee0b2cd839a6358bd1f273d0356bf964c1a1aeb32d47db0215488b",
+                "sha256:2552bffc808641c6eb471e55aa6899fa002ac94e4eebfa9ec058649122db5824",
+                "sha256:315e19a3e5c2ab47a67467fc0362cb36c7c60a93b6457f675d7d9615edad2ebe",
+                "sha256:344021ed3e639e017b452aa8f5f6bf38a8806f5852e217a7594417fb9bbfa00e",
+                "sha256:375262829c8c700c3e7cbb336810b94367b9c4889818bbd910d0ecb4e45dc261",
+                "sha256:457d8c3d42314ff47cc2d6c54f8fc0d23954b47977b2caed09cd9635cb75388b",
+                "sha256:4aed257c7484d01c9a194d9a94758b37d3d751849c05a0050c087a358c41ad1f",
+                "sha256:530948945e7b6c95e6fa7aa4be2be25764af53fba93fe76d912e35d1c9ee46f5",
+                "sha256:5ae7e989f12628f41e804847a8cc2943d362440132919a69429d4dea1f164da0",
+                "sha256:71f510b0efe1629bf2f7c0eadb1ff0b9cf611e87b73cd017e6b7d6adb40e2b3a",
+                "sha256:73f219fdc1777cf3c45fde7f0708732ec6950dfc598afc50588d0d285fddaefc",
+                "sha256:8092a368d3eb7116e270525329a3e5c15ae796ccdf7ccb17839a73b4f5084a39",
+                "sha256:82ae615826da838a8e5d4d630eb70c993ab8636f0eff13cb28aafc4291b632b5",
+                "sha256:9608000a5a45f663be6af5c70c3cbe634fa19243e720eb380c0d378666bc7702",
+                "sha256:a40dd1e9f22e01e66ed534d6a965eb99546b41d4d52dbdb66565608fde48203f",
+                "sha256:b4f5a82afa4f1ff482ab8ded2ae8a453a2cdfde2001567b3ca24a4c5c5ca0db3",
+                "sha256:c009a92e81ce836212ce7aa98b219db7961a8b95999b97af566b8dc8c33e9519",
+                "sha256:c218796d59d5abd8780170c937b812c9637e84c32f8271bbf9845970f8c1351f",
+                "sha256:cc3cd122bea268998b79adebbb8343b735a5511ec14efb70a39e7acbc11ccbdc",
+                "sha256:d0d8fd58df5d17ddb8c72a5075d87cd80d71b542571b5f78178fb067fa4e9c72",
+                "sha256:e18bc3764cbb5e118be139b3b611bc3fbc5d3be42a7e827d1096f46087b395eb",
+                "sha256:e2b83abd292194f350bb04e188f9379d36b8dfac24dd445d5c87575f3beaf789",
+                "sha256:e7469271497960b6a781eaa930cba8af400dd59b62ec9ca2f4d31a19f2f91090",
+                "sha256:e9dbacd22555c2d47f262ef96bb4e30880e5956169741400af8b306bbb24a273",
+                "sha256:f6257b314fc14958f8122779e5a1557517b0f8e500cfb2bd53fa1f75a8ad0af2"
             ],
             "index": "pypi",
-            "version": "==1.5.1"
+            "version": "==1.5.2"
         },
         "passlib": {
             "hashes": [
@@ -1202,26 +1243,32 @@
         },
         "pyproj": {
             "hashes": [
-                "sha256:11553895789640149f908a8e077cca67ae2535df071cc2f6d3b0ebcbf8adf02e",
-                "sha256:14865a582a5872ff64a90fa607a1554109d4440268050ca077be7e5d7642543d",
-                "sha256:166fce0649b40042f2ac2e5b6e13ac35be2b494681b9ed20a74f99ab59fd9fa2",
-                "sha256:3c64f3ecd3126b57dd21d2c51fbb2ba68d3120d63b6c07f9ca547d51aef8a783",
-                "sha256:4a3435e3fb51614e22f8fd57322693834b88b19685ff761d22c36be5ca836a59",
-                "sha256:52556f245f1112f121091937b47738d1fbcbd0f13be6fb32689de31ab0975d24",
-                "sha256:6da8fd4a09fc77f2750c63851bd8cd8cf4d1876573033ec6c44d29f5b4b3cea1",
-                "sha256:794be2206253a324f31caab8dd12c5de36119b5784a36cde30d0902cb78a7bb2",
-                "sha256:7e46989a0a27e700fdc011b65e058ac7d117f4a756b5a5ec9c27386fa91b47b5",
-                "sha256:925cf84980c032d2aff2c9fb78dd909b0b35d7f217c16c39a52c6b0678d5e7eb",
-                "sha256:9692d2a6b373cdb2741da23afaaf7947c4ff3b5a9e2b9d8ffeaa52eebe09bfff",
-                "sha256:9a36ba27000783d14b7b4d5c393f014cf77482168c8d31c2bb27e065b46ae56e",
-                "sha256:9c0d9a2888837d001444f9165180d5e1812954a31b03d3d716d49adb6c70b70f",
-                "sha256:aac668630b359d5df0bb6bd4474758088e2fd28aec0320e827f4fa4ad6ba6902",
-                "sha256:b4704d43fe7f7ebeffdd7bea61b361cd1c9ed6a7178b9b7b7477c56271f60e15",
-                "sha256:c4f3eb92c33d0f77d109b2f38cdb8e092d122484ffabf14e295cdde9e6536b0b",
-                "sha256:e7d08ee78d32cfa4507c1d458a9fd5cf2e8a60e3fd8b9fe9fc2f3847b1021635"
+                "sha256:2518d1606e2229b82318e704b40290e02a2a52d77b40cdcb2978973d6fc27b20",
+                "sha256:33a5d1cfbb40a019422eb80709a0e270704390ecde7278fdc0b88f3647c56a39",
+                "sha256:33c1c2968a4f4f87d517c4275a18b557e5c13907cf2609371fadea8463c3ba05",
+                "sha256:3fef83a01c1e86dd9fa99d8214f749837cfafc34d9d6230b4b0a998fa7a68a1a",
+                "sha256:451a3d1c563b672458029ebc04acbb3266cd8b3025268eb871a9176dc3638911",
+                "sha256:457ad3856014ac26af1d86def6dc8cf69c1fa377b6e2fd6e97912d51cf66bdbe",
+                "sha256:4f5b02b4abbd41610397c635b275a8ee4a2b5bc72a75572b98ac6ae7befa471e",
+                "sha256:6a212d0e5c7efa33d039f0c8b0a489e2204fcd28b56206567852ad7f5f2a653e",
+                "sha256:6f3f36440ea61f5f6da4e6beb365dddcbe159815450001d9fb753545affa45ff",
+                "sha256:93cbad7b699e8e80def7de80c350617f35e6a0b82862f8ce3c014657c25fdb3c",
+                "sha256:9f097e8f341a162438918e908be86d105a28194ff6224633b2e9616c5031153f",
+                "sha256:a13e5731b3a360ee7fbd1e9199ec9203fafcece8ebd0b1351f16d0a90cad6828",
+                "sha256:a6ac4861979cd05a0f5400fefa41d26c0269a5fb8237618aef7c998907db39e1",
+                "sha256:a8b7c8accdc61dac8e91acab7c1f7b4590d1e102f2ee9b1f1e6399fad225958e",
+                "sha256:adacb67a9f71fb54ca1b887a6ab20f32dd536fcdf2acec84a19e25ad768f7965",
+                "sha256:bc2f3a15d065e206d63edd2cc4739aa0a35c05338ee276ab1dc72f56f1944bda",
+                "sha256:cbf6ccf990860b06c5262ff97c4b78e1d07883981635cd53a6aa438a68d92945",
+                "sha256:d87836be6b720fb4d9c112136aa47621b6ca09a554e645c1081561eb8e2fa1f4",
+                "sha256:d90a5d1fdd066b0e9b22409b0f5e81933469918fa04c2cf7f9a76ce84cb29dad",
+                "sha256:daf2998e3f5bcdd579a18faf009f37f53538e9b7d0a252581a610297d31e8536",
+                "sha256:e015f900b4b84e908f8035ab16ebf02d67389c1c216c17a2196fc2e515c00762",
+                "sha256:e50d5d20b87758acf8f13f39a3b3eb21d5ef32339d2bc8cdeb8092416e0051df",
+                "sha256:f5a8015c74ec8f6508aebf493b58ba20ccb4da8168bf05f0c2a37faccb518da9"
             ],
             "index": "pypi",
-            "version": "==2.6.1"
+            "version": "==2.6.1.post1"
         },
         "pyrsistent": {
             "hashes": [
@@ -1229,6 +1276,14 @@
             ],
             "index": "pypi",
             "version": "==0.16.0"
+        },
+        "pysaml2": {
+            "hashes": [
+                "sha256:2ca155f4eeb1471b247a7b0cc79ccfd5780046d33d0b201e1199a00698dce795",
+                "sha256:f40f9576dce9afef156469179277ffeeca36829248be333252af0517a26d0b1f"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==7.2.1"
         },
         "pyshp": {
             "hashes": [
@@ -1408,11 +1463,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840",
-                "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"
+                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.6.0"
+            "version": "==65.6.3"
         },
         "shapely": {
             "hashes": [
@@ -1695,6 +1750,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.0.1"
         },
+        "xmlschema": {
+            "hashes": [
+                "sha256:5717a8a239637a9ad7d7563ce676dddf0a8989644c833f96bfc6d157c3cb3750",
+                "sha256:5ca34ff15dd3276cfb2e3e7b4c8dde4b7d4d27080f333a93b6c3f817e90abddf"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
+        },
         "z3c.pt": {
             "hashes": [
                 "sha256:238bcfdb46343f11447e6faba1f7806b8e8e40302f76ae43c26eacb28854676f",
@@ -1724,6 +1787,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1",
+                "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==3.10.0"
         },
         "zodb": {
             "hashes": [
@@ -2552,23 +2623,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d",
-                "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959",
-                "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6",
-                "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873",
-                "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2",
-                "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713",
-                "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
-                "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
-                "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
-                "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586",
-                "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3",
-                "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
-                "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
-                "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
+                "sha256:0a7dcbcd3f1913f664aca35d47c1331fce738d44ec34b7be8b9d332151b0b01e",
+                "sha256:1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b",
+                "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7",
+                "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085",
+                "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc",
+                "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d",
+                "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a",
+                "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498",
+                "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89",
+                "sha256:8695456444f277af73a4877db9fc979849cd3ee74c198d04fc0776ebc3db52b9",
+                "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c",
+                "sha256:94fff993ee9bc1b2440d3b7243d488c6a3d9724cc2b09cdb297f6a886d040ef7",
+                "sha256:9965c46c674ba8cc572bc09a03f4c649292ee73e1b683adb1ce81e82e9a6a0fb",
+                "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14",
+                "sha256:a305600e7a6b7b855cd798e00278161b681ad6e9b7eca94c721d5f588ab212af",
+                "sha256:cd65b60cfe004790c795cc35f272e41a3df4631e2fb6b35aa7ac6ef2859d554e",
+                "sha256:d2a6e5ef66503da51d2110edf6c403dc6b494cc0082f85db12f54e9c5d4c3ec5",
+                "sha256:d9ec0e67a14f9d1d48dd87a2531009a9b251c02ea42851c060b25c782516ff06",
+                "sha256:f44d141b8c4ea5eb4dbc9b3ad992d45580c1d22bf5e24363f2fbf50c2d7ae8a7"
             ],
             "index": "pypi",
-            "version": "==3.4.7"
+            "version": "==3.4.8"
         },
         "decorator": {
             "hashes": [
@@ -2609,11 +2685,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:0094fe3340ad73c490d3ffccc59cc171b161acfccccd52925c70970ba23e6d6b",
-                "sha256:43da04aae745018e8bded768e74c84423d9dc38e4c498a53439e749d90e20bc0"
+                "sha256:20d090e661bbe88a5d801ea5eb3d853564940352120c84c9a14968847aca2893",
+                "sha256:b95b2423ef18d17dcd5977732a0bf0fbbde4937f10dce24ff804581f7f3ca4e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==15.3.2"
+            "version": "==15.3.3"
         },
         "flask": {
             "hashes": [
@@ -2664,11 +2740,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
-                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
+                "sha256:d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
+                "sha256:d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.0.0"
+            "version": "==5.1.0"
         },
         "incremental": {
             "hashes": [
@@ -2696,7 +2772,7 @@
                 "sha256:7c959e3dedbf7ed81f9b9d8833df252c430610e2a4a6464ec13cd20975ce20a5",
                 "sha256:91ef03016bcf72dd17190f863476e7c799c6126ec7e8be97719d1bc9a78a59a4"
             ],
-            "markers": "python_version >= '3.4'",
+            "markers": "python_version >= '3.8'",
             "version": "==8.6.0"
         },
         "itsdangerous": {
@@ -2717,11 +2793,11 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
-                "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"
+                "sha256:203c1fd9d969ab8f2119ec0a3342e0b49910045abe6af0a3ae83a5764d54639e",
+                "sha256:bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.18.1"
+            "version": "==0.18.2"
         },
         "jeepney": {
             "hashes": [
@@ -2917,11 +2993,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:24becda58d49ceac4dc26232eb179ef2b21f133fecda7eed6018d341766ed76e",
-                "sha256:e7f2129cba4ff3b3656bbdda0e74ee00d2f874a8bcdb9dd16f5fec7b3e173cae"
+                "sha256:535c29c31216c77302877d5120aef6c94ff573748a5b5ca5b1b1f76f5e700c73",
+                "sha256:ced598b222f6f4029c0800cefaa6a17373fb580cd093223003475ce32805c35b"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.32"
+            "version": "==3.0.33"
         },
         "ptyprocess": {
             "hashes": [
@@ -3129,11 +3205,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840",
-                "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"
+                "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
+                "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.6.0"
+            "version": "==65.6.3"
         },
         "six": {
             "hashes": [
@@ -3298,7 +3374,7 @@
                 "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1",
                 "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==3.10.0"
         }
     }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ Docker-compose
 
 11. CKAN should be available at http://adr.local/
 
+
+### [DEBUG] Local db issues
+
+If you get the following error (or similar) when running ckan (step 7 above):
+
+```
+ckan  | sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "db" to address: Name or service not known
+ckan  |
+ckan  | (Background on this error at: http://sqlalche.me/e/e3q8)
+ckan exited with code 1
+```
+
+Check if the `db` container is exiting with the following message:
+
+```
+initdb: directory "/var/lib/postgresql/data" exists but is not empty"
+```
+
+Then you need to do the following:
+
+1. `docker volume inspect adx_develop_pg_data` from your local host to find your db mountpoint, e.g. `/var/lib/docker/volumes/adx_develop_pg_data/_data`
+2. `sudo rm <MOUNTPOINT>/pg_hba.conf` from your local host
+3. `adx up && adx logs ckan`
+
+Then continue with the installation as above.
+
 ### [OPTIONAL] Setting up local ckan dev venv
 
 1. For Ubuntu you'll need to satisfy psycopg2:

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -125,7 +125,7 @@ ckan.redis.url = redis://redis:6379/1
 #   Add ``resource_proxy`` to enable resorce proxying and get around the
 #   same origin policy
 # Note: Plugins to the left take precendence over plugins to the right!!! Opposite to what you might expect.
-ckan.plugins = unaids fork scheming_datasets blob_storage emailasusername restricted authz_service stats
+ckan.plugins = unaids fork scheming_datasets blob_storage saml2auth restricted authz_service stats
   text_view image_view unaids_recline_view recline_graph_view recline_map_view recline_grid_view
   resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest sentry versions
@@ -286,6 +286,20 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 
 ## Email settings
 email_to = support@fjelltopp.org
+
+# SAML2.0
+ckanext.saml2auth.idp_metadata.location = remote
+ckanext.saml2auth.idp_metadata.remote_url = https://hivtools.eu.auth0.com/samlp/metadata/lMiD8vQo1OZUPJEzd5hPvcxgTMkyY7YS
+ckanext.saml2auth.idp_metadata.remote_cert = /etc/ckan/saml_idp.crt
+ckanext.saml2auth.user_email = http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+ckanext.saml2auth.user_fullname = http://schemas.xmlsoap.org/claims/CommonName
+ckanext.saml2auth.want_response_signed = False
+ckanext.saml2auth.want_assertions_signed = True
+ckanext.saml2auth.logout_requests_signed = False
+# ckanext.saml2auth.key_file_path = /etc/ckan/saml.key
+# ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
+ckanext.saml2auth.sysadmins_list = admin@fjelltopp.org
+# ckanext.saml2auth.enable_ckan_internal_login = True
 
 ## Logging configuration
 [loggers]

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -291,14 +291,13 @@ email_to = support@fjelltopp.org
 ckanext.saml2auth.idp_metadata.location = remote
 ckanext.saml2auth.idp_metadata.remote_url = https://hivtools.eu.auth0.com/samlp/metadata/lMiD8vQo1OZUPJEzd5hPvcxgTMkyY7YS
 ckanext.saml2auth.idp_metadata.remote_cert = /etc/ckan/saml_idp.crt
+ckanext.saml2auth.user_fullname = http://schemas.xmlsoap.org/ws/2005/05/identity/claims/fullname
 ckanext.saml2auth.user_email = http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
-ckanext.saml2auth.user_fullname = http://schemas.xmlsoap.org/claims/CommonName
 ckanext.saml2auth.want_response_signed = False
 ckanext.saml2auth.want_assertions_signed = True
 ckanext.saml2auth.logout_requests_signed = False
 # ckanext.saml2auth.key_file_path = /etc/ckan/saml.key
 # ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
-ckanext.saml2auth.sysadmins_list = admin@fjelltopp.org
 # ckanext.saml2auth.enable_ckan_internal_login = True
 
 ## Logging configuration

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -298,6 +298,7 @@ ckanext.saml2auth.want_assertions_signed = True
 ckanext.saml2auth.logout_requests_signed = False
 # ckanext.saml2auth.key_file_path = /etc/ckan/saml.key
 # ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
+# Uncomment the internal login option to enable log in in offline mode
 # ckanext.saml2auth.enable_ckan_internal_login = True
 
 ## Logging configuration

--- a/ckan/ckan-entrypoint-adx.sh
+++ b/ckan/ckan-entrypoint-adx.sh
@@ -38,6 +38,7 @@ set_environment () {
   export CKAN_HOME=/usr/lib/adx_develop
   export PATH=${CKAN_VENV}/bin:${PATH}
   export CKAN_VENV=$CKAN_HOME/venv
+  echo "${ADR_CKAN_SAML_IDP_CERT}" > /etc/ckan/saml_idp.crt
 }
 
 write_config () {

--- a/demo_data/users.json
+++ b/demo_data/users.json
@@ -1,112 +1,103 @@
 {
-  "users": [
-    {
-      "email": "fjelltopp_admin@fjelltopp.org",
-      "about": null,
-      "display_name": "Fjelltopp Admin",
-      "name": "fjelltopp_admin",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Fjelltopp Admin",
-      "job_title": "Admin",
-      "affiliation": "Fjelltopp"
-    },
-    {
-      "email": "fjelltopp_editor@fjelltopp.org",
-      "about": null,
-      "display_name": "Fjelltopp Editor",
-      "name": "fjelltopp_editor",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Fjelltopp Editor",
-      "job_title": "Editor",
-      "affiliation": "Fjelltopp"
-    },
-    {
-      "email": "fjelltopp_member@fjelltopp.org",
-      "about": null,
-      "display_name": "Fjelltopp Member",
-      "name": "fjelltopp_member",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Fjelltopp Member",
-      "job_title": "Member",
-      "affiliation": "Fjelltopp"
-    },
-    {
-      "email": "north_pole_admin@northpole.org",
-      "about": null,
-      "display_name": "North Pole Admin",
-      "name": "north_pole_admin",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "North Pole Admin",
-      "job_title": "Admin",
-      "affiliation": "North Pole"
-    },
-    {
-      "email": "north_pole_editor@northpole.org",
-      "about": null,
-      "display_name": "North Pole Editor",
-      "name": "north_pole_editor",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "North Pole Editor",
-      "job_title": "Editor",
-      "affiliation": "North Pole"
-    },
-    {
-      "email": "north_pole_member@northpole.org",
-      "about": null,
-      "display_name": "North Pole Member",
-      "name": "north_pole_member",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "North Pole Member",
-      "job_title": "Member",
-      "affiliation": "North Pole"
-    },
-    {
-      "email": "cote_admin@cote.org",
-      "about": null,
-      "display_name": "Cote Admin",
-      "name": "cote_admin",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Cote Admin",
-      "job_title": "Admin",
-      "affiliation": "Cote"
-    },
-    {
-      "email": "cote_editor@cote.org",
-      "about": null,
-      "display_name": "Cote Editor",
-      "name": "cote_editor",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Cote Editor",
-      "job_title": "Editor",
-      "affiliation": "Cote"
-    },
-    {
-      "email": "cote_member@cote.org",
-      "about": null,
-      "display_name": "Cote Member",
-      "name": "cote_member",
-      "password": "fjelltopp",
-      "activity_streams_email_notifications": false,
-      "state": "active",
-      "fullname": "Cote Member",
-      "job_title": "Member",
-      "affiliation": "Cote"
-    }
-  ]
+    "users": [
+        {
+            "email": "fjelltopp_admin@fjelltopp.org",
+            "name": "fjelltopp_admin",
+            "fullname": "Fjelltopp Admin",
+            "about": null,
+            "display_name": "Fjelltopp Admin",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Admin",
+            "affiliation": "Fjelltopp"
+        },
+        {
+            "email": "fjelltopp_editor@fjelltopp.org",
+            "name": "fjelltopp_editor",
+            "fullname": "Fjelltopp Editor",
+            "about": null,
+            "display_name": "Fjelltopp Editor",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Editor",
+            "affiliation": "Fjelltopp"
+        },
+        {
+            "email": "fjelltopp_member@fjelltopp.org",
+            "name": "fjelltopp_member",
+            "fullname": "Fjelltopp Member",
+            "about": null,
+            "display_name": "Fjelltopp Member",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Member",
+            "affiliation": "Fjelltopp"
+        },
+        {
+            "email": "north_pole_admin@northpole.org",
+            "name": "north_pole_admin",
+            "fullname": "North Pole Admin",
+            "about": null,
+            "display_name": "North Pole Admin",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Admin",
+            "affiliation": "North Pole"
+        },
+        {
+            "email": "north_pole_editor@northpole.org",
+            "name": "north_pole_editor",
+            "fullname": "North Pole Editor",
+            "about": null,
+            "display_name": "North Pole Editor",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Editor",
+            "affiliation": "North Pole"
+        },
+        {
+            "email": "north_pole_member@northpole.org",
+            "name": "north_pole_member",
+            "fullname": "North Pole Member",
+            "about": null,
+            "display_name": "North Pole Member",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Member",
+            "affiliation": "North Pole"
+        },
+        {
+            "email": "cote_admin@cote.org",
+            "name": "cote_admin",
+            "fullname": "Cote Admin",
+            "about": null,
+            "display_name": "Cote Admin",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Admin",
+            "affiliation": "Cote"
+        },
+        {
+            "email": "cote_editor@cote.org",
+            "name": "cote_editor",
+            "fullname": "Cote Editor",
+            "about": null,
+            "display_name": "Cote Editor",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Editor",
+            "affiliation": "Cote"
+        },
+        {
+            "email": "cote_member@cote.org",
+            "name": "cote_member",
+            "fullname": "Cote Member",
+            "about": null,
+            "display_name": "Cote Member",
+            "activity_streams_email_notifications": false,
+            "state": "active",
+            "job_title": "Member",
+            "affiliation": "Cote"
+        }
+    ]
 }

--- a/dev.env
+++ b/dev.env
@@ -32,3 +32,9 @@ ADX_PATH=${HOME}/work/fjelltopp/adx
 GIFTLESS_AWS_ACCESS_KEY_ID=XXX
 GIFTLESS_AWS_SECRET_ACCESS_KEY=YYY
 IMAGE_TAG=development
+#
+# Auth0 certificate from "ADR Local" application
+ADR_CKAN_SAML_IDP_CERT=<GET FROM AUTH0>
+#
+# Fjelltopp common dev password - see confluence
+FJELLTOPP_PASSWORD=XXX

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -25,6 +25,7 @@ ADX_PATH = os.path.expanduser(os.environ.get(
 ))
 PG_USER = os.environ.get('PG_USER', 'ckan')
 CKAN_TEST_SQLALCHEMY_URL = os.environ.get("CKAN_TEST_SQLALCHEMY_URL", "postgresql://ckan_default:pass@db/ckan_test")
+FJELLTOPP_PASSWORD = os.environ.get("FJELLTOPP_PASSWORD", "fjelltopp")
 ADMIN_APIKEY = os.environ.get("ADMIN_APIKEY", "6011357f-a7f8-4367-a47d-8c2ab8059520")
 CKAN_SITE_URL = os.environ.get("CKAN_SITE_URL", "http://adr.local")
 SKIP_DB_RESTART = (os.environ.get("SKIP_DB_RESTART", 'false').lower() == 'true')
@@ -154,7 +155,7 @@ def init_ckan_db(args, extra):
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini versions initdb'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini pages initdb'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini opendata-request init-db'])
-    call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini user add admin email=admin@localhost name=admin fullname=Admin job_title=chief affiliation=fjelltopp password=fjelltopp apikey=a4bf5640-e1b2-4141-8c22-f2b96b6df2c3'])
+    call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini user add admin email=admin@localhost name=admin fullname=Admin job_title=chief affiliation=fjelltopp password={FJELLTOPP_PASSWORD} apikey=a4bf5640-e1b2-4141-8c22-f2b96b6df2c3'])
     call_command([f'docker exec db psql -U {PG_USER} -c "UPDATE public.user SET apikey = \'{ADMIN_APIKEY}\' WHERE name = \'admin\';"'])
     call_command(['docker exec -it ckan /usr/local/bin/ckan -c /etc/ckan/ckan.ini sysadmin add admin'])
 


### PR DESCRIPTION
Copies over the changes we have in adx_deploy for using ckanext-saml2auth for authentication.

Also ensures we can have identified users and sys admin accounts for demodata.

Currently we are using `ckanext.saml2auth.enable_ckan_internal_login = True`, with this set to True users can login the old fashioned way or by hitting the "SSO" button (so Auth0 can be used).

You can test this all with this PR and a new local .env variable `ADR_CKAN_SAML_IDP_CERT`.