### PR TITLE
Introducing custom postgres image in order to resolve corrupted pg_da…

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,31 +105,6 @@ Docker-compose
 11. CKAN should be available at http://adr.local/
 
 
-### [DEBUG] Local db issues
-
-If you get the following error (or similar) when running ckan (step 7 above):
-
-```
-ckan  | sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "db" to address: Name or service not known
-ckan  |
-ckan  | (Background on this error at: http://sqlalche.me/e/e3q8)
-ckan exited with code 1
-```
-
-Check if the `db` container is exiting with the following message:
-
-```
-initdb: directory "/var/lib/postgresql/data" exists but is not empty"
-```
-
-Then you need to do the following:
-
-1. `docker volume inspect adx_develop_pg_data` from your local host to find your db mountpoint, e.g. `/var/lib/docker/volumes/adx_develop_pg_data/_data`
-2. `sudo rm <MOUNTPOINT>/pg_hba.conf` from your local host
-3. `adx up && adx logs ckan`
-
-Then continue with the installation as above.
-
 ### [OPTIONAL] Setting up local ckan dev venv
 
 1. For Ubuntu you'll need to satisfy psycopg2:

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,12 @@
+#FROM postgres:9.6
+FROM mdillon/postgis:11
+MAINTAINER Fjelltopp
+
+# Customize default user/pass/db
+ENV POSTGRES_DB ckan
+ENV POSTGRES_USER ckan
+ARG POSTGRES_PASSWORD
+ARG DS_RO_PASS
+
+# Include datastore setup scripts
+ADD ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/db/docker-entrypoint-initdb.d/00_create_datastore.sh
+++ b/db/docker-entrypoint-initdb.d/00_create_datastore.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+    CREATE ROLE datastore_ro NOSUPERUSER NOCREATEDB NOCREATEROLE LOGIN PASSWORD '$DS_RO_PASS';
+    CREATE DATABASE datastore OWNER ckan ENCODING 'utf-8';
+    GRANT ALL PRIVILEGES ON DATABASE datastore TO ckan;
+EOSQL

--- a/db/docker-entrypoint-initdb.d/20_postgis_permissions.sql
+++ b/db/docker-entrypoint-initdb.d/20_postgis_permissions.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION POSTGIS;
+ALTER VIEW geometry_columns OWNER TO ckan;
+ALTER TABLE spatial_ref_sys OWNER TO ckan;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,7 @@ services:
       - "5432:5432"
     image: adr.db:${IMAGE_TAG}
     build:
-      context: ../ckan/
-      dockerfile: contrib/docker/postgresql/Dockerfile
+      context: ./db
       args:
         - DS_RO_PASS=datastore
         - POSTGRES_PASSWORD=ckan


### PR DESCRIPTION
…ta volume issue.

This is to resolve a common issue which has a workaround section in the README.

I have copied&pasted postgres docker image from the ckan repo and removed theese lines from the Dockerfile:
```
# Allow connections; we don't map out any ports so only linked docker containers can connect
RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
```