### PR TITLE
ADX-874 remove after login config

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -298,7 +298,7 @@ ckanext.saml2auth.logout_requests_signed = False
 # ckanext.saml2auth.key_file_path = /etc/ckan/saml.key
 # ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
 # Uncomment the internal login option to enable log in in offline mode
-# ckanext.saml2auth.enable_ckan_internal_login = False
+# ckanext.saml2auth.enable_ckan_internal_login = True
 
 ## Logging configuration
 [loggers]

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -64,7 +64,6 @@ ckan.datastore.default_fts_index_method = gist
 ckan.site_url = http://ckan:5000 # overwirtten by env var
 #ckan.use_pylons_response_cleanup_middleware = true
 ckan.resource_formats = /usr/lib/adx/ckanext-unaids/ckanext/unaids/resource_formats.json
-ckan.route_after_login = validate_user_profile.check_user_affiliation
 
 ## Ckan core settings
 
@@ -299,7 +298,7 @@ ckanext.saml2auth.logout_requests_signed = False
 # ckanext.saml2auth.key_file_path = /etc/ckan/saml.key
 # ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
 # Uncomment the internal login option to enable log in in offline mode
-# ckanext.saml2auth.enable_ckan_internal_login = True
+# ckanext.saml2auth.enable_ckan_internal_login = False
 
 ## Logging configuration
 [loggers]


### PR DESCRIPTION
As part of the change in how we deal with user affiliation and job title we no longer need the route_after_login config.