### PR TITLE
ADX 972 - update number of organizations per page to 70

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -235,8 +235,8 @@ ckan.display_timezone = server
 ckan.group_and_organization_list_all_fields_max = 1000
 ckan.group_and_organization_list_max = 1000
 
-# Number of organizations per page
-ckan.organizations_per_page = 100
+# Number of datasets/organizations per page
+ckan.datasets_per_page = 70
 
 ## Internationalisation Settings
 ckan.locale_default = en

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -235,6 +235,9 @@ ckan.display_timezone = server
 ckan.group_and_organization_list_all_fields_max = 1000
 ckan.group_and_organization_list_max = 1000
 
+# Number of items per page, including organizations as well
+ckan.datasets_per_page = 100
+
 ## Internationalisation Settings
 ckan.locale_default = en
 ckan.locale_order = en fr pt_PT

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -235,8 +235,8 @@ ckan.display_timezone = server
 ckan.group_and_organization_list_all_fields_max = 1000
 ckan.group_and_organization_list_max = 1000
 
-# Number of items per page, including organizations as well
-ckan.datasets_per_page = 100
+# Number of organizations per page
+ckan.organizations_per_page = 100
 
 ## Internationalisation Settings
 ckan.locale_default = en


### PR DESCRIPTION
## Description

Update the config variable ckan.datasets_per_page to 70 ; including datasets, organizations ...

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
