### PR TITLE
ADX-999 Remove unused ckanext-spatial.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -58,7 +58,6 @@ webencodings = "==0.5.1"
 webob = "==1.8.7"
 werkzeug = {version = "==1.0.0", extras = ["watchdog"]}
 "zope.interface" = "<5.0"
-ckanext-spatial = {editable = true, ref = "f00ad5b1d981691ffa51fbd3bbef701d569943cb", git = "https://github.com/ckan/ckanext-spatial.git"}
 ckanext-composite = {editable = true, ref = "1e6d7bb8fbe7d607376505860985c29816e64d36", git = "https://github.com/EnviDat/ckanext-composite.git"}
 ckanext-repeating = {editable = true, ref = "291295557ff74b26784f6271c1a1b4ffdb990f43", git = "https://github.com/open-data/ckanext-repeating.git"}
 ckanext-sentry = {editable = true, ref = "d3b1d1cf1f975b3672891012e6c75e176497db8f", git = "https://github.com/okfn/ckanext-sentry"}
@@ -90,12 +89,6 @@ pycparser = "==2.20"
 typing-extensions = "==4.2.0"
 typing = "==3.7.4.3"
 ckantoolkit = ">=0.0.3"
-geoalchemy = ">=0.6"
-geoalchemy2 = "==0.5.0"
-shapely = ">=1.2.13"
-pyproj = "~=2.6.1"
-argparse = "*"
-pyparsing = ">=2.1.10"
 python-slugify = "==4.0.0"
 pandas = ">=1.4.2"
 pika = ">=1.1.0"
@@ -108,10 +101,10 @@ pyshp = "==2.1.0"
 pyrsistent = "==0.16.0"
 jsonschema = "==3.2.0"
 charset-normalizer = "==2.0.12"
-owslib = "==0.18.0"
 python-dotenv = "==1.0.0"
 python-jose = "==3.3.0"
 setuptools = "==67.2.0"
+raven="6.10.0"
 
 [dev-packages]
 beautifulsoup4 = "==4.9.1"

--- a/Pipfile
+++ b/Pipfile
@@ -104,7 +104,6 @@ charset-normalizer = "==2.0.12"
 python-dotenv = "==1.0.0"
 python-jose = "==3.3.0"
 setuptools = "==67.2.0"
-raven="6.10.0"
 
 [dev-packages]
 beautifulsoup4 = "==4.9.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3327b5b6b1b1dadafa3656adc6207a4a6a9f40f4017a39a9817121c9f7f3653"
+            "sha256": "c7e4a348d7b81fc79fd8d88fd0c1d7e6af3a01265c18081365c40e90ced60b90"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,14 +23,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.0"
-        },
-        "argparse": {
-            "hashes": [
-                "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
-                "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
-            ],
-            "index": "pypi",
-            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -65,19 +57,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1ff703152553f4d5fc9774071d114dbf06ec661eb1b29b6051f6b1f9d0c24873",
-                "sha256:d0ed43228952b55c9f44d1c733f74656418c39c55dbe36bc37feeef6aa583ded"
+                "sha256:20b88a8145845e4923d438f5f89fdbdac5bae4011e706cd0974ac69c41f258b4",
+                "sha256:81bff32c96a6b4b203beb63826214d8cf24ca1a86e81d43bbb688a21c5d79e2a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.118"
+            "version": "==1.26.151"
         },
         "botocore": {
             "hashes": [
-                "sha256:44cb088a73b02dd716c5c5715143a64d5f10388957285246e11f3cc893eebf9d",
-                "sha256:b51fc5d50cbc43edaf58b3ec4fa933b82755801c453bf8908c8d3e70ae1142c1"
+                "sha256:0790bf5d25ad6f2db3450797251a78fbcb7b72cdeeb2fd0b82c2668a41d9f41c",
+                "sha256:fdaaa34ea5f09666f17d24d2f4179f7ec81dd6f831ef6b785d4552f919291cab"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.118"
+            "version": "==1.29.151"
         },
         "cached-property": {
             "hashes": [
@@ -251,11 +243,6 @@
             "git": "https://github.com/okfn/ckanext-sentry",
             "ref": "d3b1d1cf1f975b3672891012e6c75e176497db8f"
         },
-        "ckanext-spatial": {
-            "editable": true,
-            "git": "https://github.com/ckan/ckanext-spatial.git",
-            "ref": "f00ad5b1d981691ffa51fbd3bbef701d569943cb"
-        },
         "ckanext-unaids": {
             "editable": true,
             "path": "./submodules/ckanext-unaids"
@@ -348,11 +335,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+                "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+                "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.19"
+            "version": "==0.20.1"
         },
         "dominate": {
             "hashes": [
@@ -372,11 +359,11 @@
         },
         "elementpath": {
             "hashes": [
-                "sha256:3ac9735460824ed5f14c223d8de36bede2a9347e11b2775dcbf801eede1c7cdc",
-                "sha256:cd2bff3de8cddf8a480f728e648c6cae47d8ab66696c7d830a7a84536d8cae58"
+                "sha256:0bd0ef5bad559b677ba499e9c7342ca1f2ae2bace90808ee52528ec8d9f6e12b",
+                "sha256:e8a6c5685e1843c620f426c85ad21ff25cfc7554790116b1046adae7dc252458"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.1.1"
+            "version": "==4.1.2"
         },
         "et-xmlfile": {
             "hashes": [
@@ -430,22 +417,6 @@
             ],
             "index": "pypi",
             "version": "==1.0.2"
-        },
-        "geoalchemy": {
-            "hashes": [
-                "sha256:282d63d4497ed2c7b59751fe1987d8d15a8215c5024de5d2fc79e0e631b59771",
-                "sha256:78ce2f57a7982051030ccc9a59eb589bf6e0b3fad93875add4c1f7ef65f91863"
-            ],
-            "index": "pypi",
-            "version": "==0.7.2"
-        },
-        "geoalchemy2": {
-            "hashes": [
-                "sha256:7d66d01af82d22bc37d3ebb1e73713b87ac5e116b3bc82ea4ec0584bbaa89f89",
-                "sha256:eed7a62f5a13d1bbfaff708b345da663fb32ef879b662db6254b46f22bb93fe1"
-            ],
-            "index": "pypi",
-            "version": "==0.5.0"
         },
         "giftless-client": {
             "hashes": [
@@ -831,43 +802,36 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.1.2"
         },
-        "owslib": {
-            "hashes": [
-                "sha256:f5645c2f28a058a794309e0349038139f2f0e2065aa40b017d6cad5baf171705"
-            ],
-            "index": "pypi",
-            "version": "==0.18.0"
-        },
         "pandas": {
             "hashes": [
-                "sha256:00959a04a1d7bbc63d75a768540fb20ecc9e65fd80744c930e23768345a362a7",
-                "sha256:03e677c6bc9cfb7f93a8b617d44f6091613a5671ef2944818469be7b42114a00",
-                "sha256:0a514ae436b23a92366fbad8365807fc0eed15ca219690b3445dcfa33597a5cc",
-                "sha256:12bd6618e3cc737c5200ecabbbb5eaba8ab645a4b0db508ceeb4004bb10b060e",
-                "sha256:18d22cb9043b6c6804529810f492ab09d638ddf625c5dea8529239607295cb59",
-                "sha256:19b8e5270da32b41ebf12f0e7165efa7024492e9513fb46fb631c5022ae5709d",
-                "sha256:2b6fe5f7ce1cba0e74188c8473c9091ead9b293ef0a6794939f8cc7947057abd",
-                "sha256:320b180d125c3842c5da5889183b9a43da4ebba375ab2ef938f57bf267a3c684",
-                "sha256:3d099ecaa5b9e977b55cd43cf842ec13b14afa1cfa51b7e1179d90b38c53ce6a",
-                "sha256:6c0853d487b6c868bf107a4b270a823746175b1932093b537b9b76c639fc6f7e",
-                "sha256:6fa0067f2419f933101bdc6001bcea1d50812afbd367b30943417d67fbb99678",
-                "sha256:70a996a1d2432dadedbb638fe7d921c88b0cc4dd90374eab51bb33dc6c0c2a12",
-                "sha256:7b8395d335b08bc8b050590da264f94a439b4770ff16bb51798527f1dd840388",
-                "sha256:7bbf173d364130334e0159a9a034f573e8b44a05320995127cf676b85fd8ce86",
-                "sha256:8db5a644d184a38e6ed40feeb12d410d7fcc36648443defe4707022da127fc35",
-                "sha256:909a72b52175590debbf1d0c9e3e6bce2f1833c80c76d80bd1aa09188be768e5",
-                "sha256:90d1d365d77d287063c5e339f49b27bd99ef06d10a8843cf00b1a49326d492c1",
-                "sha256:910df06feaf9935d05247db6de452f6d59820e432c18a2919a92ffcd98f8f79b",
-                "sha256:99f7192d8b0e6daf8e0d0fd93baa40056684e4b4aaaef9ea78dff34168e1f2f0",
-                "sha256:a2564629b3a47b6aa303e024e3d84e850d36746f7e804347f64229f8c87416ea",
-                "sha256:a37ee35a3eb6ce523b2c064af6286c45ea1c7ff882d46e10d0945dbda7572753",
-                "sha256:af2449e9e984dfad39276b885271ba31c5e0204ffd9f21f287a245980b0e4091",
-                "sha256:e09a53a4fe8d6ae2149959a2d02e1ef2f4d2ceb285ac48f74b79798507e468b4",
-                "sha256:f25e23a03f7ad7211ffa30cb181c3e5f6d96a8e4cb22898af462a7333f8a74eb",
-                "sha256:fe7914d8ddb2d54b900cec264c090b88d141a1eed605c9539a187dbc2547f022"
+                "sha256:02755de164da6827764ceb3bbc5f64b35cb12394b1024fdf88704d0fa06e0e2f",
+                "sha256:0a1e0576611641acde15c2322228d138258f236d14b749ad9af498ab69089e2d",
+                "sha256:1eb09a242184092f424b2edd06eb2b99d06dc07eeddff9929e8667d4ed44e181",
+                "sha256:30a89d0fec4263ccbf96f68592fd668939481854d2ff9da709d32a047689393b",
+                "sha256:50e451932b3011b61d2961b4185382c92cc8c6ee4658dcd4f320687bb2d000ee",
+                "sha256:51a93d422fbb1bd04b67639ba4b5368dffc26923f3ea32a275d2cc450f1d1c86",
+                "sha256:598e9020d85a8cdbaa1815eb325a91cfff2bb2b23c1442549b8a3668e36f0f77",
+                "sha256:66d00300f188fa5de73f92d5725ced162488f6dc6ad4cecfe4144ca29debe3b8",
+                "sha256:69167693cb8f9b3fc060956a5d0a0a8dbfed5f980d9fd2c306fb5b9c855c814c",
+                "sha256:6d6d10c2142d11d40d6e6c0a190b1f89f525bcf85564707e31b0a39e3b398e08",
+                "sha256:713f2f70abcdade1ddd68fc91577cb090b3544b07ceba78a12f799355a13ee44",
+                "sha256:7376e13d28eb16752c398ca1d36ccfe52bf7e887067af9a0474de6331dd948d2",
+                "sha256:77550c8909ebc23e56a89f91b40ad01b50c42cfbfab49b3393694a50549295ea",
+                "sha256:7b21cb72958fc49ad757685db1919021d99650d7aaba676576c9e88d3889d456",
+                "sha256:9ebb9f1c22ddb828e7fd017ea265a59d80461d5a79154b49a4207bd17514d122",
+                "sha256:a18e5c72b989ff0f7197707ceddc99828320d0ca22ab50dd1b9e37db45b010c0",
+                "sha256:a6b5f14cd24a2ed06e14255ff40fe2ea0cfaef79a8dd68069b7ace74bd6acbba",
+                "sha256:b42b120458636a981077cfcfa8568c031b3e8709701315e2bfa866324a83efa8",
+                "sha256:c4af689352c4fe3d75b2834933ee9d0ccdbf5d7a8a7264f0ce9524e877820c08",
+                "sha256:c7319b6e68de14e6209460f72a8d1ef13c09fb3d3ef6c37c1e65b35d50b5c145",
+                "sha256:cf3f0c361a4270185baa89ec7ab92ecaa355fe783791457077473f974f654df5",
+                "sha256:dd46bde7309088481b1cf9c58e3f0e204b9ff9e3244f441accd220dd3365ce7c",
+                "sha256:dd5476b6c3fe410ee95926873f377b856dbc4e81a9c605a0dc05aaccc6a7c6c6",
+                "sha256:e69140bc2d29a8556f55445c15f5794490852af3de0f609a24003ef174528b79",
+                "sha256:f908a77cbeef9bbd646bd4b81214cbef9ac3dda4181d5092a4aa9797d1bc7774"
             ],
             "index": "pypi",
-            "version": "==2.0.1"
+            "version": "==2.0.2"
         },
         "passlib": {
             "hashes": [
@@ -879,11 +843,11 @@
         },
         "pika": {
             "hashes": [
-                "sha256:89f5e606646caebe3c00cbdbc4c2c609834adde45d7507311807b5775edac8e0",
-                "sha256:beb19ff6dd1547f99a29acc2c6987ebb2ba7c44bf44a3f8e305877c5ef7d2fdc"
+                "sha256:0779a7c1fafd805672796085560d290213a465e4f6f76a6fb19e378d8041a14f",
+                "sha256:b2a327ddddf8570b4965b3576ac77091b850262d34ce8c1d8cb4e4146aa4145f"
             ],
             "index": "pypi",
-            "version": "==1.3.1"
+            "version": "==1.3.2"
         },
         "polib": {
             "hashes": [
@@ -951,43 +915,6 @@
             ],
             "index": "pypi",
             "version": "==18.0.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
-            ],
-            "index": "pypi",
-            "version": "==3.0.9"
-        },
-        "pyproj": {
-            "hashes": [
-                "sha256:2518d1606e2229b82318e704b40290e02a2a52d77b40cdcb2978973d6fc27b20",
-                "sha256:33a5d1cfbb40a019422eb80709a0e270704390ecde7278fdc0b88f3647c56a39",
-                "sha256:33c1c2968a4f4f87d517c4275a18b557e5c13907cf2609371fadea8463c3ba05",
-                "sha256:3fef83a01c1e86dd9fa99d8214f749837cfafc34d9d6230b4b0a998fa7a68a1a",
-                "sha256:451a3d1c563b672458029ebc04acbb3266cd8b3025268eb871a9176dc3638911",
-                "sha256:457ad3856014ac26af1d86def6dc8cf69c1fa377b6e2fd6e97912d51cf66bdbe",
-                "sha256:4f5b02b4abbd41610397c635b275a8ee4a2b5bc72a75572b98ac6ae7befa471e",
-                "sha256:6a212d0e5c7efa33d039f0c8b0a489e2204fcd28b56206567852ad7f5f2a653e",
-                "sha256:6f3f36440ea61f5f6da4e6beb365dddcbe159815450001d9fb753545affa45ff",
-                "sha256:93cbad7b699e8e80def7de80c350617f35e6a0b82862f8ce3c014657c25fdb3c",
-                "sha256:9f097e8f341a162438918e908be86d105a28194ff6224633b2e9616c5031153f",
-                "sha256:a13e5731b3a360ee7fbd1e9199ec9203fafcece8ebd0b1351f16d0a90cad6828",
-                "sha256:a6ac4861979cd05a0f5400fefa41d26c0269a5fb8237618aef7c998907db39e1",
-                "sha256:a8b7c8accdc61dac8e91acab7c1f7b4590d1e102f2ee9b1f1e6399fad225958e",
-                "sha256:adacb67a9f71fb54ca1b887a6ab20f32dd536fcdf2acec84a19e25ad768f7965",
-                "sha256:bc2f3a15d065e206d63edd2cc4739aa0a35c05338ee276ab1dc72f56f1944bda",
-                "sha256:cbf6ccf990860b06c5262ff97c4b78e1d07883981635cd53a6aa438a68d92945",
-                "sha256:d87836be6b720fb4d9c112136aa47621b6ca09a554e645c1081561eb8e2fa1f4",
-                "sha256:d90a5d1fdd066b0e9b22409b0f5e81933469918fa04c2cf7f9a76ce84cb29dad",
-                "sha256:daf2998e3f5bcdd579a18faf009f37f53538e9b7d0a252581a610297d31e8536",
-                "sha256:e015f900b4b84e908f8035ab16ebf02d67389c1c216c17a2196fc2e515c00762",
-                "sha256:e50d5d20b87758acf8f13f39a3b3eb21d5ef32339d2bc8cdeb8092416e0051df",
-                "sha256:f5a8015c74ec8f6508aebf493b58ba20ccb4da8168bf05f0c2a37faccb518da9"
-            ],
-            "index": "pypi",
-            "version": "==2.6.1.post1"
         },
         "pyrsistent": {
             "hashes": [
@@ -1109,6 +1036,7 @@
                 "sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54",
                 "sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4"
             ],
+            "index": "pypi",
             "version": "==6.10.0"
         },
         "redis": {
@@ -1170,16 +1098,16 @@
                 "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
                 "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
             "version": "==4.9"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd",
-                "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"
+                "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346",
+                "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.0"
+            "version": "==0.6.1"
         },
         "setuptools": {
             "hashes": [
@@ -1188,50 +1116,6 @@
             ],
             "index": "pypi",
             "version": "==67.2.0"
-        },
-        "shapely": {
-            "hashes": [
-                "sha256:01224899ff692a62929ef1a3f5fe389043e262698a708ab7569f43a99a48ae82",
-                "sha256:05c51a29336e604c084fb43ae5dbbfa2c0ef9bd6fedeae0a0d02c7b57a56ba46",
-                "sha256:09d6c7763b1bee0d0a2b84bb32a4c25c6359ad1ac582a62d8b211e89de986154",
-                "sha256:193a398d81c97a62fc3634a1a33798a58fd1dcf4aead254d080b273efbb7e3ff",
-                "sha256:1a34a23d6266ca162499e4a22b79159dc0052f4973d16f16f990baa4d29e58b6",
-                "sha256:2569a4b91caeef54dd5ae9091ae6f63526d8ca0b376b5bb9fd1a3195d047d7d4",
-                "sha256:33403b8896e1d98aaa3a52110d828b18985d740cc9f34f198922018b1e0f8afe",
-                "sha256:3ad81f292fffbd568ae71828e6c387da7eb5384a79db9b4fde14dd9fdeffca9a",
-                "sha256:3cb256ae0c01b17f7bc68ee2ffdd45aebf42af8992484ea55c29a6151abe4386",
-                "sha256:45b4833235b90bc87ee26c6537438fa77559d994d2d3be5190dd2e54d31b2820",
-                "sha256:4641325e065fd3e07d55677849c9ddfd0cf3ee98f96475126942e746d55b17c8",
-                "sha256:502e0a607f1dcc6dee0125aeee886379be5242c854500ea5fd2e7ac076b9ce6d",
-                "sha256:66a6b1a3e72ece97fc85536a281476f9b7794de2e646ca8a4517e2e3c1446893",
-                "sha256:70a18fc7d6418e5aea76ac55dce33f98e75bd413c6eb39cfed6a1ba36469d7d4",
-                "sha256:7d3bbeefd8a6a1a1017265d2d36f8ff2d79d0162d8c141aa0d37a87063525656",
-                "sha256:83a8ec0ee0192b6e3feee9f6a499d1377e9c295af74d7f81ecba5a42a6b195b7",
-                "sha256:865bc3d7cc0ea63189d11a0b1120d1307ed7a64720a8bfa5be2fde5fc6d0d33f",
-                "sha256:90cfa4144ff189a3c3de62e2f3669283c98fb760cfa2e82ff70df40f11cadb39",
-                "sha256:91575d97fd67391b85686573d758896ed2fc7476321c9d2e2b0c398b628b961c",
-                "sha256:9a6ac34c16f4d5d3c174c76c9d7614ec8fe735f8f82b6cc97a46b54f386a86bf",
-                "sha256:a529218e72a3dbdc83676198e610485fdfa31178f4be5b519a8ae12ea688db14",
-                "sha256:a70a614791ff65f5e283feed747e1cc3d9e6c6ba91556e640636bbb0a1e32a71",
-                "sha256:ac1dfc397475d1de485e76de0c3c91cc9d79bd39012a84bb0f5e8a199fc17bef",
-                "sha256:b06d031bc64149e340448fea25eee01360a58936c89985cf584134171e05863f",
-                "sha256:b4f0711cc83734c6fad94fc8d4ec30f3d52c1787b17d9dca261dc841d4731c64",
-                "sha256:b50c401b64883e61556a90b89948297f1714dbac29243d17ed9284a47e6dd731",
-                "sha256:b519cf3726ddb6c67f6a951d1bb1d29691111eaa67ea19ddca4d454fbe35949c",
-                "sha256:bca57b683e3d94d0919e2f31e4d70fdfbb7059650ef1b431d9f4e045690edcd5",
-                "sha256:c43755d2c46b75a7b74ac6226d2cc9fa2a76c3263c5ae70c195c6fb4e7b08e79",
-                "sha256:c7eed1fb3008a8a4a56425334b7eb82651a51f9e9a9c2f72844a2fb394f38a6c",
-                "sha256:c8b0d834b11be97d5ab2b4dceada20ae8e07bcccbc0f55d71df6729965f406ad",
-                "sha256:ce88ec79df55430e37178a191ad8df45cae90b0f6972d46d867bf6ebbb58cc4d",
-                "sha256:d173d24e85e51510e658fb108513d5bc11e3fd2820db6b1bd0522266ddd11f51",
-                "sha256:d8f55f355be7821dade839df785a49dc9f16d1af363134d07eb11e9207e0b189",
-                "sha256:da71de5bf552d83dcc21b78cc0020e86f8d0feea43e202110973987ffa781c21",
-                "sha256:e55698e0ed95a70fe9ff9a23c763acfe0bf335b02df12142f74e4543095e9a9b",
-                "sha256:f32a748703e7bf6e92dfa3d2936b2fbfe76f8ce5f756e24f49ef72d17d26ad02",
-                "sha256:f470a130d6ddb05b810fc1776d918659407f8d025b7f56d2742a596b6dffa6c7"
-            ],
-            "index": "pypi",
-            "version": "==2.0.1"
         },
         "shutilwhich": {
             "hashes": [
@@ -1441,11 +1325,11 @@
         },
         "xmlschema": {
             "hashes": [
-                "sha256:7d971045eeeb8de183b56bc7530eb8f3d8276072d08017a962c2c34e93bfdd26",
-                "sha256:d21ba86af4432720231fb4b40f1205fa75fd718d6856ec3b8118984de31c225b"
+                "sha256:c2d583f7d07c6bac157d075889d15c128f34afdc79e4f70b4fb3c6adedc59bfe",
+                "sha256:e4c275c8a9ad9c5d4e92f0bac2b68103b688a0df1fb72c6feabaa5f5a2994836"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.3"
+            "version": "==2.3.0"
         },
         "zipp": {
             "hashes": [
@@ -1780,11 +1664,11 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
-                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
+                "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6",
+                "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.19"
+            "version": "==0.20.1"
         },
         "executing": {
             "hashes": [
@@ -1803,11 +1687,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:170ead9d0d140916168b142df69c44722b8f622ced2070802d0af9c476f0cb84",
-                "sha256:977ad0b7aa7a61ed57287d6a0723a827e9d3dd1f8cc82aaf08707f281b33bacc"
+                "sha256:633b278caa3ec239463f9139c74da2607c8da5710e56d5d7d30fc8a7440104c4",
+                "sha256:d9f363720c4a6cf9884c6c3e26e2ce26266ffe5d741a9bc7cb9256779bc62190"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==18.4.0"
+            "version": "==18.10.1"
         },
         "flask": {
             "hashes": [
@@ -1896,11 +1780,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:1c183bf61b148b00bcebfa5d9b39312733ae97f6dad90d7e9b4d86c8647f498c",
-                "sha256:a950236df04ad75b5bc7f816f9af3d74dc118fd42f2ff7e80e8e60ca1f182e2d"
+                "sha256:c7b80eb7f5a855a88efc971fda506ff7a91c280b42cdae26643e0f601ea281ea",
+                "sha256:ea8801f15dfe4ffb76dea1b09b847430ffd70d827b41735c64a0638a04103bfc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==8.12.0"
+            "version": "==8.12.2"
         },
         "itsdangerous": {
             "hashes": [
@@ -2096,11 +1980,11 @@
         },
         "pip": {
             "hashes": [
-                "sha256:3d8d72fa0714e93c9d3c2a0ede91e898c64596e0fa7d4523f72dd95728efc418",
-                "sha256:c95b53d309f903f33dfe5fd37e502a5c3a05ee3454d518e45df522a4f091b728"
+                "sha256:0e7c86f486935893c708287b30bd050a36ac827ec7fe5e43fe7cb198dd835fba",
+                "sha256:3ef6ac33239e4027d9a5598a381b9d30880a1477e50039db2eac6e8a8f6d1b18"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.1.1"
+            "version": "==23.1.2"
         },
         "pip-tools": {
             "hashes": [
@@ -2139,7 +2023,7 @@
                 "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
                 "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==3.0.38"
         },
         "ptyprocess": {
@@ -2182,10 +2066,10 @@
         },
         "pydevd-pycharm": {
             "hashes": [
-                "sha256:607eb16a0d0e28dd05f68b7b332fd1dcc2cce1faae28db2e0b2df6765edebd7f"
+                "sha256:7737e29a29fa27bc4d40ee067ed85195a42722237ccc41873fb02e5e0e91e622"
             ],
             "index": "pypi",
-            "version": "==231.8770.15"
+            "version": "==232.7295.8"
         },
         "pyfakefs": {
             "hashes": [
@@ -2300,11 +2184,11 @@
         },
         "requests-toolbelt": {
             "hashes": [
-                "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
-                "sha256:62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d"
+                "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+                "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.1"
+            "version": "==1.0.0"
         },
         "responses": {
             "hashes": [
@@ -2324,11 +2208,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:22b74cae0278fd5086ff44144d3813be1cedc9115bdfabbfefd86400cb88b20a",
-                "sha256:b5d573e13605423ec80bdd0cd5f8541f7844a0e71a13f74cf454ccb2f490708b"
+                "sha256:76f6b65ea7e5c5d924ba80e322231d7cb5b5981aa60bfc1e694f1bc097fe6fe1",
+                "sha256:d204aadb50b936bf6b1a695385429d192bc1fdaf3e8b907e8e26f4c4e4b5bf75"
             ],
-            "markers": "python_full_version >= '3.7.0'",
-            "version": "==13.3.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==13.4.1"
         },
         "secretstorage": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c7e4a348d7b81fc79fd8d88fd0c1d7e6af3a01265c18081365c40e90ced60b90"
+            "sha256": "c55e11f00fb2b849763124caf0f20464c60fd48a8a1e7c92bed2745362e75624"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -57,19 +57,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:20b88a8145845e4923d438f5f89fdbdac5bae4011e706cd0974ac69c41f258b4",
-                "sha256:81bff32c96a6b4b203beb63826214d8cf24ca1a86e81d43bbb688a21c5d79e2a"
+                "sha256:0be407c2e941b422634766c0d754132ad4d33b5d0f84d9a30426b713b31ce3ab",
+                "sha256:7f88d9403f81e6f3fc770c424f7089b15eb0553b168b1d2f979fa0d12b663b42"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.26.151"
+            "version": "==1.26.158"
         },
         "botocore": {
             "hashes": [
-                "sha256:0790bf5d25ad6f2db3450797251a78fbcb7b72cdeeb2fd0b82c2668a41d9f41c",
-                "sha256:fdaaa34ea5f09666f17d24d2f4179f7ec81dd6f831ef6b785d4552f919291cab"
+                "sha256:267d4e7f36bdb45ea696386143ca6f68a358dc4baef85894cc4d9cffe97c0cd5",
+                "sha256:2fd3b625f3d683d9dd6b400aba54d54a1e9b960b84ed07a466d25d1366e59482"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.151"
+            "version": "==1.29.158"
         },
         "cached-property": {
             "hashes": [
@@ -359,11 +359,11 @@
         },
         "elementpath": {
             "hashes": [
-                "sha256:0bd0ef5bad559b677ba499e9c7342ca1f2ae2bace90808ee52528ec8d9f6e12b",
-                "sha256:e8a6c5685e1843c620f426c85ad21ff25cfc7554790116b1046adae7dc252458"
+                "sha256:1ce703e1380ef12efe1b6aeb1927c0f3add0e4f77950d89d9d44136d6676794b",
+                "sha256:569553e39c8c7edf63e61bdf0f439ffd6ba5548a300571091dd2938b1d27a201"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.1.2"
+            "version": "==4.1.3"
         },
         "et-xmlfile": {
             "hashes": [
@@ -444,86 +444,86 @@
         },
         "ijson": {
             "hashes": [
-                "sha256:00594ed3ef2218fee8c652d9e7f862fb39f8251b67c6379ef12f7e044bf6bbf3",
-                "sha256:03dfd4c8ed19e704d04b0ad4f34f598dc569fd3f73089f80eed698e7f6069233",
-                "sha256:09fe3a53e00c59de33b825ba8d6d39f544a7d7180983cd3d6bd2c3794ae35442",
-                "sha256:0eb838b4e4360e65c00aa13c78b35afc2477759d423b602b60335af5bed3de5b",
-                "sha256:11bb84a53c37e227e733c6dffad2037391cf0b3474bff78596dc4373b02008a0",
-                "sha256:11dfd64633fe1382c4237477ac3836f682ca17e25e0d0799e84737795b0611df",
-                "sha256:1302dc6490da7d44c3a76a5f0b87d8bec9f918454c6d6e6bf4ed922e47da58bb",
-                "sha256:13f2939db983327dd0492f6c1c0e77be3f2cbf9b620c92c7547d1d2cd6ef0486",
-                "sha256:158494bfe89ccb32618d0e53b471364080ceb975462ec464d9f9f37d9832b653",
-                "sha256:183841b8d033ca95457f61fb0719185dc7f51a616070bdf1dcaf03473bed05b2",
-                "sha256:1a75cfb34217b41136b714985be645f12269e4345da35d7b48aabd317c82fd10",
-                "sha256:1d64ffaab1d006a4fa9584a4c723e95cc9609bf6c3365478e250cd0bffaaadf3",
-                "sha256:25919b444426f58dcc62f763d1c6be6297f309da85ecab55f51da6ca86fc9fdf",
-                "sha256:26b57838e712b8852c40ec6d74c6de8bb226446440e1af1354c077a6f81b9142",
-                "sha256:27409ba44cfd006901971063d37699f72e092b5efaa1586288b5067d80c6b5bd",
-                "sha256:2d50b2ad9c6c51ca160aa60de7f4dacd1357c38d0e503f51aed95c1c1945ff53",
-                "sha256:2f204f6d4cedeb28326c230a0b046968b5263c234c65a5b18cee22865800fff7",
-                "sha256:2f9d449f86f8971c24609e319811f7f3b6b734f0218c4a0e799debe19300d15b",
-                "sha256:3b21b1ecd20ed2f918f6f99cdfa68284a416c0f015ffa64b68fa933df1b24d40",
-                "sha256:3ccc4d4b947549f9c431651c02b95ef571412c78f88ded198612a41d5c5701a0",
-                "sha256:41e955e173f77f54337fecaaa58a35c464b75e232b1f939b282497134a4d4f0e",
-                "sha256:424232c2bf3e8181f1b572db92c179c2376b57eba9fc8931453fba975f48cb80",
-                "sha256:434e57e7ec5c334ccb0e67bb4d9e60c264dcb2a3843713dbeb12cb19fe42a668",
-                "sha256:47a56e3628c227081a2aa58569cbf2af378bad8af648aa904080e87cd6644cfb",
-                "sha256:4d4e143908f47307042c9678803d27706e0e2099d0a6c1988c6cae1da07760bf",
-                "sha256:4e7c4fdc7d24747c8cc7d528c145afda4de23210bf4054bd98cd63bf07e4882d",
-                "sha256:51c1db80d7791fb761ad9a6c70f521acd2c4b0e5afa2fe0d813beb2140d16c37",
-                "sha256:5242cb2313ba3ece307b426efa56424ac13cc291c36f292b501d412a98ad0703",
-                "sha256:535665a77408b6bea56eb828806fae125846dff2e2e0ed4cb2e0a8e36244d753",
-                "sha256:535a59d61b9aef6fc2a3d01564c1151e38e5a44b92cd6583cb4e8ccf0f58043f",
-                "sha256:53f1a13eb99ab514c562869513172135d4b55a914b344e6518ba09ad3ef1e503",
-                "sha256:5418066666b25b05f2b8ae2698408daa0afa68f07b0b217f2ab24465b7e9cbd9",
-                "sha256:56500dac8f52989ef7c0075257a8b471cbea8ef77f1044822742b3cbf2246e8b",
-                "sha256:5809752045ef74c26adf159ed03df7fb7e7a8d656992fd7562663ed47d6d39d9",
-                "sha256:5c93ae4d49d8cf8accfedc8a8e7815851f56ceb6e399b0c186754a68fed22844",
-                "sha256:5d365df54d18076f1d5f2ffb1eef2ac7f0d067789838f13d393b5586fbb77b02",
-                "sha256:6def9ac8d73b76cb02e9e9837763f27f71e5e67ec0afae5f1f4cf8f61c39b1ac",
-                "sha256:6ee9537e8a8aa15dd2d0912737aeb6265e781e74f7f7cad8165048fcb5f39230",
-                "sha256:6eed1ddd3147de49226db4f213851cf7860493a7b6c7bd5e62516941c007094c",
-                "sha256:6fd55f7a46429de95383fc0d0158c1bfb798e976d59d52830337343c2d9bda5c",
-                "sha256:775444a3b647350158d0b3c6c39c88b4a0995643a076cb104bf25042c9aedcf8",
-                "sha256:79b94662c2e9d366ab362c2c5858097eae0da100dea0dfd340db09ab28c8d5e8",
-                "sha256:7e0d1713a9074a7677eb8e43f424b731589d1c689d4676e2f57a5ce59d089e89",
-                "sha256:80a5bd7e9923cab200701f67ad2372104328b99ddf249dbbe8834102c852d316",
-                "sha256:830de03f391f7e72b8587bb178c22d534da31153e9ee4234d54ef82cde5ace5e",
-                "sha256:84eed88177f6c243c52b280cb094f751de600d98d2221e0dec331920894889ec",
-                "sha256:8f20072376e338af0e51ccecb02335b4e242d55a9218a640f545be7fc64cca99",
-                "sha256:93aaec00cbde65c192f15c21f3ee44d2ab0c11eb1a35020b5c4c2676f7fe01d0",
-                "sha256:9829a17f6f78d7f4d0aeff28c126926a1e5f86828ebb60d6a0acfa0d08457f9f",
-                "sha256:986a0347fe19e5117a5241276b72add570839e5bcdc7a6dac4b538c5928eeff5",
-                "sha256:992e9e68003df32e2aa0f31eb82c0a94f21286203ab2f2b2c666410e17b59d2f",
-                "sha256:9ecbf85a6d73fc72f6534c38f7d92ed15d212e29e0dbe9810a465d61c8a66d23",
-                "sha256:a340413a9bf307fafd99254a4dd4ac6c567b91a205bf896dde18888315fd7fcd",
-                "sha256:a4465c90b25ca7903410fabe4145e7b45493295cc3b84ec1216653fbe9021276",
-                "sha256:a7698bc480df76073067017f73ba4139dbaae20f7a6c9a0c7855b9c5e9a62124",
-                "sha256:a8af68fe579f6f0b9a8b3f033d10caacfed6a4b89b8c7a1d9478a8f5d8aba4a1",
-                "sha256:a8c84dff2d60ae06d5280ec87cd63050bbd74a90c02bfc7c390c803cfc8ac8fc",
-                "sha256:b3456cd5b16ec9db3ef23dd27f37bf5a14f765e8272e9af3e3de9ee9a4cba867",
-                "sha256:b3bdd2e12d9b9a18713dd6f3c5ef3734fdab25b79b177054ba9e35ecc746cb6e",
-                "sha256:b3c6cf18b61b94db9590f86af0dd60edbccb36e151643152b8688066f677fbc9",
-                "sha256:b3e8d46c1004afcf2bf513a8fb575ee2ec3d8009a2668566b5926a2dcf7f1a45",
-                "sha256:bced6cd5b09d4d002dda9f37292dd58d26eb1c4d0d179b820d3708d776300bb4",
-                "sha256:bed8dcb7dbfdb98e647ad47676045e0891f610d38095dcfdae468e1e1efb2766",
-                "sha256:c85892d68895ba7a0b16a0e6b7d9f9a0e30e86f2b1e0f6986243473ba8735432",
-                "sha256:c8646eb81eec559d7d8b1e51a5087299d06ecab3bc7da54c01f7df94350df135",
-                "sha256:cd0450e76b9c629b7f86e7d5b91b7cc9c281dd719630160a992b19a856f7bdbd",
-                "sha256:ce4be2beece2629bd24bcab147741d1532bd5ed40fb52f2b4fcde5c5bf606df0",
-                "sha256:d3e255ef05b434f20fc9d4b18ea15733d1038bec3e4960d772b06216fa79e82d",
-                "sha256:dcec67fc15e5978ad286e8cc2a3f9347076e28e0e01673b5ace18c73da64e3ff",
-                "sha256:e97e6e07851cefe7baa41f1ebf5c0899d2d00d94bfef59825752e4c784bebbe8",
-                "sha256:eb167ee21d9c413d6b0ab65ec12f3e7ea0122879da8b3569fa1063526f9f03a8",
-                "sha256:efee1e9b4f691e1086730f3010e31c55625bc2e0f7db292a38a2cdf2774c2e13",
-                "sha256:f349bee14d0a4a72ba41e1b1cce52af324ebf704f5066c09e3dd04cfa6f545f0",
-                "sha256:f470f3d750e00df86e03254fdcb422d2f726f4fb3a0d8eeee35e81343985e58a",
-                "sha256:f6464242f7895268d3086d7829ef031b05c77870dad1e13e51ef79d0a9cfe029",
-                "sha256:f6785ba0f65eb64b1ce3b7fcfec101085faf98f4e77b234f14287fd4138ffb25",
-                "sha256:fd218b338ac68213c997d4c88437c0e726f16d301616bf837e1468901934042c",
-                "sha256:fe7f414edd69dd9199b0dfffa0ada22f23d8009e10fe2a719e0993b7dcc2e6e2"
+                "sha256:0199456b6b3d830d8850c99327da5fad293ead515e656768941263e8c588ff28",
+                "sha256:07151b4d83763a5e3ee8f61c1dcd350f6a955c60200cd1d8f9989049667fa3c4",
+                "sha256:08debb0373ff86dd912b3d8fd4e40b759fc2d474191754beb72ea1044edb8947",
+                "sha256:0aa0e0bbd205ee8ad4f64443f002cc23f668492c96d19d3181d1904fc9a46eb6",
+                "sha256:0cf5911658aa102a6c726bca58a72a08b910cc97e4168ae3a9b308b826f95194",
+                "sha256:13957abec999a5961cd046125e667c33c79feb8e876efea6f2f86b188c3172f2",
+                "sha256:163fe391bfb7a024063d7020b0afc0db615d5bf112e92acc87d93b627c53c7b1",
+                "sha256:1c3643092a7895a7ffc21b6188d79de4ed0f4f4052eb278c6d7e20387f7d7074",
+                "sha256:27d2383190cbe0560fe91a99e7c35aa8e46c41283fc6fcb8d00a08d19cfc3ff0",
+                "sha256:2a47e44dd758304e88b679eed6d322a1ad6feffb124d74d9f59071003243c9c9",
+                "sha256:34126c5c8027116d94a6725ba0bbd12727e4d5a0c5592f5ba636bd141fc7ed70",
+                "sha256:3575ccf1119ed5d373fa7de882978e8e6172ffe16bae9dbb4ca708caf45bcee0",
+                "sha256:360c234f2759103fc024ae6e257f92689e0d48d96346dbcacbbbe81fbad7712e",
+                "sha256:3700d5d9d196ce4b9da40a09f49e05e75d64f45765dbebe5cb4af74ec6dc039b",
+                "sha256:3d8b55e6bc5e1e079a834f5bbfc30b0cc49444e1e9a33f1e4bede933dfecdabc",
+                "sha256:3f1d3979951288000534b258461ce5d9388078c306d9c12af04153bb6a5f36f3",
+                "sha256:40cbd9d14ff6fd4d6dd047cbec31e0c25466c91489378753c9c5feb78bfd23ba",
+                "sha256:48e0925dea7a4357cd824ef71834f1e444fd9d9536b076a304e4e3219c0133d5",
+                "sha256:4a981d22b8f89be2db50def8a9e92d87c3b86f4e36be5d93130962654f5baa3f",
+                "sha256:4f206866b90ff79702b82aee5910e52a6a1a2a8d91333ad3454d17cde996eea2",
+                "sha256:4faca5c72ab53462f2f688ac9cfc5e31974bb46a539bca78d0830e5b28635b63",
+                "sha256:53092b6408a1671b2ed10a153b277bd718d76fed311a34643792a488dea6a6eb",
+                "sha256:54df86de05de3a1cf1269a1cd161468df542765720b5717d0740048fc0d57363",
+                "sha256:580c6635d3cf3c591b43e6c70e70b945bb947d23b1651cf7e8c0bb770b25852f",
+                "sha256:5d2a4fafcddb0dc7a716df7e68fa4bb8b226d8cf54af27c2e614ca2249989950",
+                "sha256:5f03c1b1285743e6b688d2927105d1e6c5e6837832db88c9d57550219e757ae8",
+                "sha256:60289cadada7e3d4499730e6340d493ef9ca7de31fae9e5381809f99bada38f5",
+                "sha256:68aecc259ec213e2af9ce9472e7cc7f8158420229c8dcf0338528bf4261dbaf9",
+                "sha256:68bc6e4d0bdb1afcdbc7747ea75859f784942d82d359d1b2d5a88d18a7ac0cca",
+                "sha256:6a3972531b04e86725f5c0e9b55a91024278235b40d1a80fee53edc5e0b73634",
+                "sha256:72007e353e00292a8b9d7a2558b1360d4351fae806fddc31832964228ce20698",
+                "sha256:737384969a1e94c508be4109fda4bb060d81aa2f21d52cdfd32568ace98bec5d",
+                "sha256:759397feea371ac757033884896a92b881fbba284a93751681c2d2397aa82634",
+                "sha256:77ca22acd49f1e6cf9e1747a82cfec2a919f00c93c882218e4773aa7f9121dff",
+                "sha256:7b93a76ac6f07c1f32323cde2ab90758d2dd229f3cf193c09616de211be25bb3",
+                "sha256:7d809f8ba3295c2d91bdc4f4a522c93973481a6d09232481e5b056fe88294bf0",
+                "sha256:822f2fe7a3c1e2ff62b2578159a7b4bf752db308eb907276a528dd6b919a232e",
+                "sha256:861d15df0783e8a96311b6bcbd45b1a738bf938fd2240eeec4e84a2def0dd16a",
+                "sha256:88b3547a702a5c5038dd1b99ebf2116af6c40c9dba246d51662e8c9f739e25f7",
+                "sha256:8d4cf867c3fe88981bac3094e0842047811e5bf3894abb6d8b3408a25cd8a177",
+                "sha256:8eddcf9a7d08e404231d8457b856ba9b62aa0b4cdcf2bf64b3bac2e8eca73743",
+                "sha256:8febaa3d81d0c62ba16ae10bd112edfa2e2b24a481a9952ba56770b6f1947d4a",
+                "sha256:938ef367eef58287b65b721e7f769346f8e5bcc6726330dcb11ffd131ef633f8",
+                "sha256:95a16530f07fd576a70cc3482f9935d1b5f7207e87cf62facfa19b9d027977c4",
+                "sha256:97b7ee99be6f564b4bab7317a060469d5a18bcfa0ae85f9be3db1c2146694977",
+                "sha256:9eec9d145d6ea6bd24ca147c07a49f80a9feadbe3d0b665d6144f2f94d6bf06f",
+                "sha256:9f3c95f8694ccd018159d51e25dd87f8021880ef49a52a5a91ea946d8e18d35e",
+                "sha256:9f6debf5f06d628ae43a680d6ecd0e26d2c3c54b0b1e1c3a103a7085545e5dd1",
+                "sha256:a5001813b8d6558bda9af6bb24a3fae99377d92eb6b41ddd1ec4df548683d604",
+                "sha256:a5ff3714342262a748d21f55ebff350247c2ad64c506f9361cd2204d5fe390d7",
+                "sha256:a86c05d08f6f122e60dc391859144bd61d2d9be880d257f61bb267a4b2556b0d",
+                "sha256:ab56d4f8e40ebb4004ffcddeeab982900dabfa7fef4b58a6654da3ca678d339a",
+                "sha256:ac48d9b11782ed6198efedae29761a1f4fb0a87485c7a7fdecf790825629c1c8",
+                "sha256:ac7c78f99003e340b0d4c2465ecaf75505686c7fd4abbb21187ad009823ecd33",
+                "sha256:af0ff99cbdb0fb2d176d3fba1035a957bb52e1f7c3b579d06159f78e7520801d",
+                "sha256:afb95a065eb3179a4e0765e9c48e2ffb5a43aba583ceae3891d52e75ee94f01c",
+                "sha256:b21ad922095a6bdc3d284680f601367de8ccafdde1c6f1515ac1004499b58939",
+                "sha256:b65ea9b9932d9baa716188914c8b40d677f4e23bd94a45f42da45d064cb69677",
+                "sha256:b75592e9196294eb4e19cde4d4f39dcdc3eefddcdfbc96ae7ec8843d0817e802",
+                "sha256:b9883c8716001d7a5c8185905208e40a77eef9b2a73dbce4d189ceb092aa93bd",
+                "sha256:ba97de4442c031181581f16695308528380fd0ba904adc7ed1799b077fc61a15",
+                "sha256:bfa3d2fa57225d90af42c436a23c1829c6b8c40ce105534266f81a98755d6fb2",
+                "sha256:c0c7ad1df5ce587815dbfa2db09e110ebe43ada287736a1bf00e783e9d6bcc14",
+                "sha256:d9c3919a2f937b9771d6e4d2e4dfd5ab9596c9cc63ba06471ad612525e13eef2",
+                "sha256:dd4f9a69c0aef16f088804beb2d2c7e9e430b388f628de9116f2874440ffb45d",
+                "sha256:dd591fb5d8e86c4e79be5a48d4489af064f10de679fe4697842c4812ff678628",
+                "sha256:e51cbf1c3659ae88ebeae597a7e8a4f5b92be9678a235dd5317ff76b3b3017e5",
+                "sha256:e5e103494cb05fc814c00eda9e5e32f6a0ddc0a85fd9763df41548946bd04c0f",
+                "sha256:e62b879d85d3000541997244bbaa45eccbaf50e4bbde8239ba2011fec9ce1f9c",
+                "sha256:e96631f4dd97a1f9ff9bb8c816a7794a202753d34048ecb9d5a4b0bf7a55c5e3",
+                "sha256:ed0de6b9a3082b28ecc5e5ae72dac8a5378ef1b50cf11f21d65a5d5343c0327d",
+                "sha256:edbc3fdfcba8c68437d9799e2ebe36f338e2149b546fc6b0de7dbb4067980fca",
+                "sha256:f1d59dfc5cb2f0c9ba756b0a63070e8e3f015318a56fb396f3046f9df0b48042",
+                "sha256:f1dbb2f38a816066669875ef0ac5f65389e9678ee922301e05d411404b443dc5",
+                "sha256:f5356b7776951756a7a7e310f12cf525c516d60b7f834c946844ce2dfef58a0a",
+                "sha256:f677ce65733e385c049ef90d527c4d7312120e0f68fd9bf0d33021c374398576",
+                "sha256:faabf7789769ac73b8be3ca7baf76e9fce3901bfeeebc9682edb2a5f0314b9d3",
+                "sha256:fee77bbdf86d3c64219479a06f95bd737bce376c2ab04df36c8c386505ada678"
             ],
-            "version": "==3.2.0.post0"
+            "version": "==3.2.2"
         },
         "importlib-resources": {
             "hashes": [
@@ -574,11 +574,10 @@
         },
         "jsonpointer": {
             "hashes": [
-                "sha256:51801e558539b4e9cd268638c078c6c5746c9ac96bc38152d443400e4f3793e9",
-                "sha256:97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a"
+                "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==2.4"
         },
         "jsonschema": {
             "hashes": [
@@ -1036,7 +1035,6 @@
                 "sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54",
                 "sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4"
             ],
-            "index": "pypi",
             "version": "==6.10.0"
         },
         "redis": {
@@ -1098,7 +1096,7 @@
                 "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7",
                 "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"
             ],
-            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==4.9"
         },
         "s3transfer": {
@@ -1325,11 +1323,11 @@
         },
         "xmlschema": {
             "hashes": [
-                "sha256:c2d583f7d07c6bac157d075889d15c128f34afdc79e4f70b4fb3c6adedc59bfe",
-                "sha256:e4c275c8a9ad9c5d4e92f0bac2b68103b688a0df1fb72c6feabaa5f5a2994836"
+                "sha256:2eb426c5710833a05610c22c8766713a1b87e9405e3eca0b7c658375bf7ec810",
+                "sha256:eac0e10957723689ff0691785da4ffee1e95df3a874e685a179047f7bf07f8fb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "zipp": {
             "hashes": [
@@ -1687,11 +1685,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:633b278caa3ec239463f9139c74da2607c8da5710e56d5d7d30fc8a7440104c4",
-                "sha256:d9f363720c4a6cf9884c6c3e26e2ce26266ffe5d741a9bc7cb9256779bc62190"
+                "sha256:02980fe15acd58861305568bae0a277680792a505a5a45a309d352f79c452dd1",
+                "sha256:df4ee36d058a6a96de9d5e645571ef8536946a0b62db841494f8a3bc3bcdc5af"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==18.10.1"
+            "version": "==18.11.1"
         },
         "flask": {
             "hashes": [
@@ -1742,11 +1740,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed",
-                "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"
+                "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4",
+                "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.6.0"
+            "version": "==6.7.0"
         },
         "importlib-resources": {
             "hashes": [
@@ -1835,19 +1833,19 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
-                "sha256:ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678"
+                "sha256:b3eaa3874e2cffeba2d73e3f275c83827156d0616a2160a610a60d63922ad24b",
+                "sha256:f77da625a448baa77906b099be9feaa29aa90979547506ac1ec422926085cee0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.13.1"
+            "version": "==24.0.1"
         },
         "markdown-it-py": {
             "hashes": [
-                "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
-                "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"
+                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
         },
         "markupsafe": {
             "hashes": [
@@ -2004,11 +2002,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+                "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849",
+                "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.0"
         },
         "poyo": {
             "hashes": [
@@ -2023,7 +2021,7 @@
                 "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
                 "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.0.38"
         },
         "ptyprocess": {
@@ -2121,11 +2119,11 @@
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b",
-                "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"
+                "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39",
+                "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"
             ],
             "index": "pypi",
-            "version": "==3.10.0"
+            "version": "==3.11.1"
         },
         "pytest-rerunfailures": {
             "hashes": [
@@ -2168,11 +2166,11 @@
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
-                "sha256:f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343"
+                "sha256:9f77b519d96d03d7d7dce44977ba543090a14397c4f60de5b6eb5b8048110aa4",
+                "sha256:e18feb2a1e7706f2865b81ebb460056d93fb29d69daa10b223c00faa7bd9a00a"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==37.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==40.0"
         },
         "requests": {
             "hashes": [
@@ -2208,11 +2206,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:76f6b65ea7e5c5d924ba80e322231d7cb5b5981aa60bfc1e694f1bc097fe6fe1",
-                "sha256:d204aadb50b936bf6b1a695385429d192bc1fdaf3e8b907e8e26f4c4e4b5bf75"
+                "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec",
+                "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==13.4.1"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==13.4.2"
         },
         "secretstorage": {
             "hashes": [

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -q -y update \
     && apt-get -q clean \
     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install pipenv
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt install nodejs -y && npm version
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install nodejs npm -y && npm version
 RUN npm install --global yarn
 RUN mkdir -p /var/lib/ckan/resources && chmod 777 -R /var/lib/ckan
 

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -126,7 +126,7 @@ ckan.redis.url = redis://redis:6379/1
 # Note: Plugins to the left take precendence over plugins to the right!!! Opposite to what you might expect.
 ckan.plugins = unaids fork scheming_datasets blob_storage saml2auth emailasusername restricted authz_service stats
   text_view image_view unaids_recline_view recline_graph_view recline_map_view recline_grid_view
-  resource_proxy geo_view pdf_view datastore datapusher spatial_metadata spatial_query geojson_view composite
+  resource_proxy geo_view pdf_view datastore datapusher geojson_view composite
   validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest sentry versions
   auth
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,19 +1,11 @@
 FROM postgres:12-bullseye
 MAINTAINER Fjelltopp
 
-# after https://github.com/postgis/docker-postgis/blob/master/12-3.3/Dockerfile
-ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.3.3+dfsg-1~exp1.pgdg110+1
-
 RUN apt-get update \
-      && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
            # ca-certificates: for accessing remote raster files;
            #   fix: https://github.com/postgis/docker-postgis/issues/307
            ca-certificates \
-           \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 
 # Customize default user/pass/db

--- a/db/docker-entrypoint-initdb.d/20_postgis_permissions.sql
+++ b/db/docker-entrypoint-initdb.d/20_postgis_permissions.sql
@@ -1,3 +1,0 @@
-CREATE EXTENSION IF NOT EXISTS postgis;
-ALTER VIEW geometry_columns OWNER TO ckan;
-ALTER TABLE spatial_ref_sys OWNER TO ckan;


### PR DESCRIPTION
## ADX-999 Remove unused ckanext-spatial.

ADR uses only geoview which was moved to separate extension. Since ckanext-spatial is not used anymore, it has been removed.

Apart from ckanext-spatial itself libraries required only by ckanext-spatial have been removed from Pipfile as well. To make sure nothing got broken all tests were run on CKAN 2.9 with and without the extension and its dependencies - all results were same.

## Dependency Changes (delete if not applicable)

Removed dependecies:
* geoalchemy
* geoalchemy2
* shapely
* pyproj
* pyparsing
* argparse
* owslib

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
