### PR TITLE
ADX-1009 Seamless integration of APE with ADR

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -175,6 +175,7 @@ ckanext.validation.formats = csv xlsx xls shp geojson
 ckanext.unaids.auth0_domain =
 ckanext.unaids.oauth2_api_audience =
 ckanext.unaids.oauth2_required_scope = access:adr
+ckanext.unaids.ape_url = http://ape.minikube
 
 scheming.dataset_schemas_directory = /usr/lib/adx/submodules/unaids_data_specifications/package_schemas
 


### PR DESCRIPTION
## ADX-1009 Seamless integration of APE with ADR

Creating a config variable that contains APE's address.

relates fjelltopp/ckanext-unaids#281

## Environment Changes

New variable added: ckanext.unaids.ape_url that contains APE's url.

## Internationalisation and Localisation

Do any UI changes require internationalisation (i18n) or localisation (l10n) changes.
If new translations are required, have you created new Jira tickets for each language and informed the appropriate project manager?

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
