### PR TITLE
ADX-1043 Remove composite & repeating extensions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -58,8 +58,6 @@ webencodings = "==0.5.1"
 webob = "==1.8.7"
 werkzeug = {version = "==1.0.0", extras = ["watchdog"]}
 "zope.interface" = "<5.0"
-ckanext-composite = {editable = true, ref = "1e6d7bb8fbe7d607376505860985c29816e64d36", git = "https://github.com/EnviDat/ckanext-composite.git"}
-ckanext-repeating = {editable = true, ref = "291295557ff74b26784f6271c1a1b4ffdb990f43", git = "https://github.com/open-data/ckanext-repeating.git"}
 ckanext-sentry = {editable = true, ref = "d3b1d1cf1f975b3672891012e6c75e176497db8f", git = "https://github.com/okfn/ckanext-sentry"}
 ckanext-authz-service = {editable = true, ref = "bd4c80f55a714c1117a0e130d07463e383c494c7", git = "https://github.com/datopian/ckanext-authz-service"}
 ckanext-pdfview = {editable = true, ref = "3acd4a5d4cf53ca46bd3681e13e5d3ada051c644", git = "https://github.com/ckan/ckanext-pdfview.git"}

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -126,8 +126,8 @@ ckan.redis.url = redis://redis:6379/1
 # Note: Plugins to the left take precendence over plugins to the right!!! Opposite to what you might expect.
 ckan.plugins = unaids fork scheming_datasets blob_storage saml2auth emailasusername restricted authz_service stats
   text_view image_view unaids_recline_view recline_graph_view recline_map_view recline_grid_view
-  resource_proxy geo_view pdf_view datastore datapusher geojson_view composite
-  validation repeating ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest sentry versions
+  resource_proxy geo_view pdf_view datastore datapusher geojson_view
+  validation ytp_request pages dhis2harvester_plugin dhis2_pivot_tables_harvester harvest sentry versions
   auth
 
 ckanext.blob_storage.storage_service_url=http://adr.local/giftless
@@ -181,8 +181,6 @@ scheming.dataset_schemas_directory = /usr/lib/adx/submodules/unaids_data_specifi
 
 scheming.presets = ckanext.unaids:presets.json
                    ckanext.scheming:presets.json
-                   ckanext.repeating:presets.json
-                   ckanext.composite:presets.json
                    ckanext.validation:presets.json
 
 


### PR DESCRIPTION
## Description
The composite and repeating extensions are no longer required by our fork of ckanext-restricted. 

They were installed in very early days of the ADR. 

We have rewritten the ckanext-restricted so that it no longer depends on the presets made available by these extensions.  

Relates to https://github.com/fjelltopp/adx_deploy/pull/357

## Dependency Changes (delete if not applicable)

Removed the dependancy upon ckanext-rtepeating and ckanext-composite. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
