### PR TITLE
ADX-1061 Custom tile server configured to OpenStreetMap server

### DIFF
--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -177,7 +177,7 @@ ckanext.validation.default_validation_options = {"limit_rows": 50000, "limit_err
 ckanext.unaids.auth0_domain =
 ckanext.unaids.oauth2_api_audience =
 ckanext.unaids.oauth2_required_scope = access:adr
-ckanext.unaids.profile_editor_url = http://localhost:3000
+ckanext.unaids.profile_editor_url = http://profile-editor.minikube
 
 scheming.dataset_schemas_directory = /usr/lib/adx/submodules/unaids_data_specifications/package_schemas
 
@@ -224,7 +224,6 @@ ckan.gravatar_default = identicon
 ckan.preview.direct = png jpg gif
 ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
 ckan.display_timezone = server
-
 
 # Google Analytics Settings
 # ckan.googleanalytics_id = NOT_SET # Set as an env var from the AWS secrets manager

--- a/ckan/adx_config.ini
+++ b/ckan/adx_config.ini
@@ -177,7 +177,7 @@ ckanext.validation.default_validation_options = {"limit_rows": 50000, "limit_err
 ckanext.unaids.auth0_domain =
 ckanext.unaids.oauth2_api_audience =
 ckanext.unaids.oauth2_required_scope = access:adr
-ckanext.unaids.profile_editor_url = http://profile-editor.minikube
+ckanext.unaids.profile_editor_url = http://localhost:3000
 
 scheming.dataset_schemas_directory = /usr/lib/adx/submodules/unaids_data_specifications/package_schemas
 
@@ -224,6 +224,7 @@ ckan.gravatar_default = identicon
 ckan.preview.direct = png jpg gif
 ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
 ckan.display_timezone = server
+
 
 # Google Analytics Settings
 # ckan.googleanalytics_id = NOT_SET # Set as an env var from the AWS secrets manager
@@ -307,6 +308,11 @@ ckanext.saml2auth.logout_requests_signed = False
 # ckanext.saml2auth.cert_file_path = /etc/ckan/saml.crt
 # Uncomment the internal login option to enable log in in offline mode
 # ckanext.saml2auth.enable_ckan_internal_login = True
+
+## ckanext-scheming
+ckanext.spatial.common_map.type = custom
+ckanext.spatial.common_map.custom.url = https://tile.openstreetmap.org/{z}/{x}/{y}.png
+ckanext.spatial.common_map.attribution = &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors
 
 ## Logging configuration
 [loggers]


### PR DESCRIPTION
## Description

New map tile server configured due to Stamap (ckanext-spatial default option) shutting down its services.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
