### PR TITLE
Bump ckanext-unaids and add support link config

### DIFF
--- a/deploy/base.ini
+++ b/deploy/base.ini
@@ -257,6 +257,9 @@ ckanext.blob_storage.use_scheming_file_uploader = True
 
 # Validation
 ckanext.unaids.schema_directory = /usr/lib/ckan/submodules/unaids_data_specifications/table_schemas
+
+# Support
+ckanext.unaids.support_url = https://avenirhealthsupport.freshdesk.com/support/tickets/new
 ckanext.validation.run_on_create_async = True
 ckanext.validation.run_on_update_async = True
 ckanext.validation.run_on_create_sync = False


### PR DESCRIPTION
## Summary
- Bumps `ckanext-unaids` submodule to `a1bb13a` (https://github.com/fjelltopp/ckanext-unaids/pull/340, https://github.com/fjelltopp/ckanext-unaids/pull/341)
- Adds `ckanext.unaids.support_url` to `deploy/base.ini`, pointing at the Freshdesk support ticket form