### PR TITLE
Update ckanext-unaids and configure Freshdesk widget

### DIFF
--- a/deploy/base.ini
+++ b/deploy/base.ini
@@ -260,6 +260,8 @@ ckanext.unaids.schema_directory = /usr/lib/ckan/submodules/unaids_data_specifica
 
 # Support
 ckanext.unaids.support_url = https://avenirhealthsupport.freshdesk.com/support/tickets/new
+ckanext.unaids.freshdesk_widget_id = 156000001542
+ckanext.unaids.freshdesk_app_name = AIDS Data Repository (ADR)
 ckanext.validation.run_on_create_async = True
 ckanext.validation.run_on_update_async = True
 ckanext.validation.run_on_create_sync = False


### PR DESCRIPTION
Bumps `ckanext-unaids` to fjelltopp/ckanext-unaids#342, which adds the in-page Freshdesk feedback widget.

Sets:
- `ckanext.unaids.freshdesk_widget_id = 156000001542`
- `ckanext.unaids.freshdesk_app_name = AIDS Data Repository (ADR)`
